### PR TITLE
fix(apollo): throw error when signing with x25519

### DIFF
--- a/apollo/Apollo.ts
+++ b/apollo/Apollo.ts
@@ -28,7 +28,8 @@ import { Ed25519PublicKey } from "./utils/Ed25519PublicKey";
 import { X25519PrivateKey } from "./utils/X25519PrivateKey";
 import { Ed25519KeyPair } from "./utils/Ed25519KeyPair";
 import { X25519KeyPair } from "./utils/X25519KeyPair";
-import { base64url } from "multiformats/bases/base64";
+import { ApolloError } from "../domain/models/Errors";
+
 const EC = elliptic.ec;
 
 export default class Apollo implements ApolloInterface {
@@ -170,21 +171,18 @@ export default class Apollo implements ApolloInterface {
   }
   signByteArrayMessage(privateKey: PrivateKey, message: Uint8Array): Signature {
     const messageBuffer = Buffer.from(message);
-    if (privateKey.keyCurve.curve == Curve.ED25519) {
+    if (privateKey.keyCurve.curve === Curve.ED25519) {
       const ed25519PrivateKey = new Ed25519PrivateKey(
         Buffer.from(privateKey.value)
       );
       return {
         value: Buffer.from(ed25519PrivateKey.sign(messageBuffer)),
       };
-    } else if (privateKey.keyCurve.curve == Curve.X25519) {
-      const x25519PrivateKeyPair = new X25519PrivateKey(
-        Buffer.from(privateKey.value)
+    } else if (privateKey.keyCurve.curve === Curve.X25519) {
+      throw new ApolloError.InvalidKeyCurve(
+        "X25519 key cannot be used for signatures"
       );
-      return {
-        value: Buffer.from(x25519PrivateKeyPair.sign(messageBuffer)),
-      };
-    } else if (privateKey.keyCurve.curve == Curve.SECP256K1) {
+    } else if (privateKey.keyCurve.curve === Curve.SECP256K1) {
       const secp256k1PrivateKey = Secp256k1PrivateKey.secp256k1FromBytes(
         privateKey.value
       );
@@ -207,12 +205,14 @@ export default class Apollo implements ApolloInterface {
   ): boolean {
     const challengeBuffer = Buffer.from(challenge);
     const signatureBuffer = Buffer.from(signature);
-    if (publicKey.keyCurve.curve == Curve.ED25519) {
+    if (publicKey.keyCurve.curve === Curve.ED25519) {
       const ed25519PublicKey = new Ed25519PublicKey(publicKey.value);
       return ed25519PublicKey.verify(challengeBuffer, signatureBuffer);
-    } else if (publicKey.keyCurve.curve == Curve.X25519) {
-      throw new Error("Method not implemented.");
-    } else if (publicKey.keyCurve.curve == Curve.SECP256K1) {
+    } else if (publicKey.keyCurve.curve === Curve.X25519) {
+      throw new ApolloError.InvalidKeyCurve(
+        "X25519 key cannot be used for signatures"
+      );
+    } else if (publicKey.keyCurve.curve === Curve.SECP256K1) {
       const compressed = this.compressedPublicKeyFromPublicKey(publicKey);
       const secp256k1PublicKey = Secp256k1PublicKey.secp256k1FromCompressed(
         compressed.value

--- a/tests/apollo/Apollo.test.ts
+++ b/tests/apollo/Apollo.test.ts
@@ -1,18 +1,15 @@
 import BN from "bn.js";
 import { expect, assert } from "chai";
-import { base64url } from "multiformats/bases/base64";
 
 import { Secp256k1KeyPair } from "../../apollo/utils/Secp256k1KeyPair";
 
 import Apollo from "../../apollo/Apollo";
 import { ECConfig } from "../../config/ECConfig";
-import { Curve, PrivateKey } from "../../domain/models";
+import { Curve } from "../../domain/models";
 import { MnemonicWordList } from "../../domain/models/WordList";
 import { bip39Vectors } from "./derivation/BipVectors";
 import { Secp256k1PrivateKey } from "../../apollo/utils/Secp256k1PrivateKey";
-
-import { Ed25519KeyPair } from "../../apollo/utils/Ed25519KeyPair";
-import { X25519KeyPair } from "../../apollo/utils/X25519KeyPair";
+import { ApolloError } from "../../domain/models/Errors";
 
 let apollo: Apollo;
 
@@ -205,5 +202,22 @@ describe("Apollo Tests", () => {
       signature.value
     );
     expect(verified).to.be.equal(false);
+  });
+
+  it("Throws error when sign and verify is attempted with X25519 KeyPair", async () => {
+    const text = Buffer.from("AtalaPrism Wallet SDK");
+    const apollo = new Apollo();
+    const seed = apollo.createRandomSeed().seed;
+    const keyPair = apollo.createKeyPairFromKeyCurve(seed, {
+      curve: Curve.X25519,
+    });
+
+    expect(() =>
+      apollo.signByteArrayMessage(keyPair.privateKey, text)
+    ).to.throw(ApolloError.InvalidKeyCurve);
+
+    expect(() =>
+      apollo.verifySignature(keyPair.publicKey, text, new Uint8Array())
+    ).to.throw(ApolloError.InvalidKeyCurve);
   });
 });


### PR DESCRIPTION
# Description
<!-- What this PR does, and why is needed, a useful description is expected -->
Updated `signByteArrayMessage` method in Apollo to throw if signing is attempted with X25519 key.

# Jira link
<!-- Please add Jira ticket -->
https://input-output.atlassian.net/browse/ATL-3759

# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually
