### PR TITLE
ci: fixes slack tag link in slack

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -19,7 +19,7 @@ plugins:
     onSuccessTemplate: {
       text: "A new version of `$package_name` successfully released!\n
         Version: `$npm_package_version`\n
-        Tag: $repo_url/releases/tag/$npm_package_version\n
+        Tag: $repo_url/releases/tag/v$npm_package_version\n
         \n
         Release notes:\n
         $release_notes" } } ]


### PR DESCRIPTION
Fixes a minor issue in slack release message (missing an `v` in tag link)