### PR TITLE
fix(apollo): Create keyPair from privateKey, support ed25519 and x25519 keyCurves.

### DIFF
--- a/tests/apollo/Apollo.test.ts
+++ b/tests/apollo/Apollo.test.ts
@@ -162,6 +162,36 @@ describe("Apollo Tests", () => {
     );
   });
 
+  it("Should create a ED25519 publicKey from a privateKey", async () => {
+    const apollo = new Apollo();
+    const keyPair = apollo.createKeyPairFromKeyCurve({
+      curve: Curve.ED25519,
+    });
+
+    const keyPairFromPrivate = apollo.createKeyPairFromPrivateKey(
+      keyPair.privateKey
+    );
+
+    expect(Buffer.from(keyPair.publicKey.value).toString("hex")).to.equal(
+      Buffer.from(keyPairFromPrivate.publicKey.value).toString("hex")
+    );
+  });
+
+  it("Should create a x25519 publicKey from a privateKey", async () => {
+    const apollo = new Apollo();
+    const keyPair = apollo.createKeyPairFromKeyCurve({
+      curve: Curve.X25519,
+    });
+
+    const keyPairFromPrivate = apollo.createKeyPairFromPrivateKey(
+      keyPair.privateKey
+    );
+
+    expect(Buffer.from(keyPair.publicKey.value).toString("hex")).to.equal(
+      Buffer.from(keyPairFromPrivate.publicKey.value).toString("hex")
+    );
+  });
+
   it("Should only verify signed message using the correct SECP256K1 KeyPair", async () => {
     const text = Buffer.from("AtalaPrism Wallet SDK");
     const apollo = new Apollo();


### PR DESCRIPTION
# Description
This is a fix on previously merged PR for task  ATL-4058 to create a keyPair from a privateKey, we were only creating secp256K1KeyPairs rather than checking for the correct keyCurve and doing the same operation.

The new keyCurves, ed25519 and x25519 have been covered each of them by a single test.



# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [ ] Self-reviewed the diff
- [x] New code has inline documentation
- [x] New code has proper comments/tests
- [x] Any changes not covered by tests have been tested manually
