### PR TITLE
fix(Pluto): encoding / decoding PrivateKeys

### DIFF
--- a/src/apollo/utils/Ed25519PrivateKey.ts
+++ b/src/apollo/utils/Ed25519PrivateKey.ts
@@ -16,6 +16,7 @@ export class Ed25519PrivateKey extends PrivateKey implements SignableKey {
   public raw: Uint8Array;
   public keySpecification: Map<string, string> = new Map();
 
+  // TODO - nativeValue wants a Buffer, otherwise getInstance breaks
   constructor(nativeValue: Uint8Array) {
     super();
     this.raw = nativeValue;
@@ -44,4 +45,15 @@ export class Ed25519PrivateKey extends PrivateKey implements SignableKey {
     const signature = this.getInstance().sign(message);
     return signature.toBytes();
   }
+
+  public readonly to = {
+    Buffer: () => this.getEncoded(),
+    Hex: () => this.to.Buffer().toString("hex")
+  };
+
+  static from = {
+    Buffer: (value: Buffer) => new Ed25519PrivateKey(value),
+    Hex: (value: string) => Ed25519PrivateKey.from.Buffer(Buffer.from(value, "hex")),
+    String: (value: string) => Ed25519PrivateKey.from.Buffer(Buffer.from(value)),
+  };
 }

--- a/src/apollo/utils/Secp256k1PrivateKey.ts
+++ b/src/apollo/utils/Secp256k1PrivateKey.ts
@@ -49,6 +49,12 @@ export class Secp256k1PrivateKey extends PrivateKey implements SignableKey {
     return new Uint8Array([...padding, ...byteList]);
   }
 
+  sign(message: Buffer) {
+    const keyPair = Secp256k1PrivateKey.ec.keyFromPrivate(this.getEncoded());
+    const sig = keyPair.sign(message);
+    return Buffer.from(sig.toDER());
+  }
+
   static secp256k1FromBigInteger(bigInteger: BN): Secp256k1PrivateKey {
     return new Secp256k1PrivateKey(Uint8Array.from(bigInteger.toArray()));
   }
@@ -61,9 +67,14 @@ export class Secp256k1PrivateKey extends PrivateKey implements SignableKey {
     return new Secp256k1PrivateKey(Uint8Array.from(bnprv.toArray()));
   }
 
-  sign(message: Buffer) {
-    const keyPair = Secp256k1PrivateKey.ec.keyFromPrivate(this.getEncoded());
-    const sig = keyPair.sign(message);
-    return Buffer.from(sig.toDER());
-  }
+  public readonly to = {
+    Buffer: () => Buffer.from(this.getEncoded()),
+    Hex: () => this.to.Buffer().toString("hex")
+  };
+
+  static from = {
+    Buffer: (value: Buffer) => Secp256k1PrivateKey.secp256k1FromBytes(new Uint8Array(value)),
+    Hex: (value: string) => Secp256k1PrivateKey.from.Buffer(Buffer.from(value, "hex")),
+    String: (value: string) => Secp256k1PrivateKey.from.Buffer(Buffer.from(value))
+  };
 }

--- a/src/apollo/utils/X25519PrivateKey.ts
+++ b/src/apollo/utils/X25519PrivateKey.ts
@@ -32,4 +32,16 @@ export class X25519PrivateKey extends PrivateKey {
     const pub = base64url.baseEncode(x25519PrivateKey.publicKey);
     return new X25519PublicKey(Buffer.from(pub));
   }
+
+  public readonly to = {
+    Buffer: () => this.getEncoded(),
+    Hex: () => this.to.Buffer().toString("hex")
+  };
+
+  static from = {
+    Buffer: (value: Buffer) => new X25519PrivateKey(new Uint8Array(value)),
+    Hex: (value: string) => X25519PrivateKey.from.Buffer(Buffer.from(value, "hex")),
+    String: (value: string) => X25519PrivateKey.from.Buffer(Buffer.from(value))
+  };
+
 }

--- a/src/domain/models/keyManagement/PrivateKey.ts
+++ b/src/domain/models/keyManagement/PrivateKey.ts
@@ -15,4 +15,9 @@ export abstract class PrivateKey extends Key {
     return this.raw;
   }
   abstract publicKey(): PublicKey;
+
+  abstract to: {
+    Buffer: () => Buffer;
+    Hex: () => string;
+  };
 }

--- a/src/prism-agent/Agent.Credentials.ts
+++ b/src/prism-agent/Agent.Credentials.ts
@@ -233,7 +233,7 @@ export class AgentCredentials implements AgentCredentialsClass {
 
     const signedJWT = await jwt.sign(
       didInfo.did,
-      base64url.baseDecode(Buffer.from(prismPrivateKey.value).toString()),
+      prismPrivateKey,
       {
         iss: didInfo.did.toString(),
         aud: domain,

--- a/tests/apollo/JWT.test.ts
+++ b/tests/apollo/JWT.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { Ed25519PrivateKey } from "../../src/apollo/utils/Ed25519PrivateKey";
+import { Secp256k1PrivateKey } from "../../src/apollo/utils/Secp256k1PrivateKey";
+import { X25519PrivateKey } from "../../src/apollo/utils/X25519PrivateKey";
+import { DID } from "../../src/domain";
+import { JWT } from "../../src/apollo/utils/jwt/JWT";
+
+
+describe("Apollo - JWT", () => {
+  describe("sign", () => {
+    [
+      Ed25519PrivateKey,
+      X25519PrivateKey,
+      Secp256k1PrivateKey
+    ].forEach(keyClass => {
+      test(`${keyClass.name} - can sign with raw key (Uint8Array)`, async function () {
+        const prismDid = DID.fromString("did:prism:dadsa:1231321dhsauda23847");
+        const privateKey = keyClass.from.Hex("5ee38f66d07fc5a7f3968b33564bbd3b00eaddd481365838a9d6d3ad2fb82f41");
+
+        const sut = new JWT({} as any);
+
+        const result = await sut.sign(prismDid, privateKey.raw, { testing: 123 });
+        expect(result).to.be.a.string;
+      });
+
+      test(`${keyClass.name} - can sign with PrivateKey`, async function () {
+        const prismDid = DID.fromString("did:prism:dadsa:1231321dhsauda23847");
+        const privateKey = keyClass.from.Hex("5ee38f66d07fc5a7f3968b33564bbd3b00eaddd481365838a9d6d3ad2fb82f41");
+
+        const sut = new JWT({} as any);
+
+        const result = await sut.sign(prismDid, privateKey, { testing: 123 });
+        expect(result).to.be.a.string;
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description
  - Added some helper functions for conversions to the different PrivateKeys
  - Pluto:
    -  changed to use `PrivateKey.to.Hex` and `PrivateKey.from.Hex` for the conversions, so all keys convert into a legible string and back
    - `storePrivateKeys`: changed to store as hex
    - `getAllPeerDids`: changed to convert  from hex
    - `getDIDPrivateKeysByDID`: changed to handle Secp256 and convert from hex
    - `getDIDPrivateKeyByID`: changed to handle Secp256 and convert from hex
  - Added unit tests for simple cases

# Jira link
https://input-output.atlassian.net/browse/ATL-5537


# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually
