### PR TITLE
feat(Mercury): adding return_route: all to didcomm Message

### DIFF
--- a/src/mercury/didcomm/Wrapper.ts
+++ b/src/mercury/didcomm/Wrapper.ts
@@ -84,10 +84,9 @@ export class DIDCommWrapper implements DIDCommProtocol {
       //expires_time: Number(message.expiresTimePlus),
       thid: message.thid,
       pthid: message.pthid,
-      //TODO: Remove comment once fixed by rootsID or we are sure this works,
-      //if not message is not correctly formatted
-      //return_route: "all",
+      return_route: "all",
     });
+
     const [encryptedMsg] = await didcommMsg.pack_encrypted(
       to,
       fromDid ? fromDid.toString() : null,


### PR DESCRIPTION
# Description
Adding return_route: all to didcomm Message, to align with mediator.

Tested with node demo
  - old code fails expectedly with test message
  - new code test message is sent and received

# Jira link
https://input-output.atlassian.net/browse/ATL-5398


# Checklist
<!-- Details you need to consider that are commonly forgotten -->
<!-- Pre-submit checklist should be marked as completed when PR moves out from DRAFT -->
- [x] Self-reviewed the diff
- [ ] New code has inline documentation
- [ ] New code has proper comments/tests
- [ ] Any changes not covered by tests have been tested manually
