### PR TITLE
fix: escape the `<->` sequence to fix the build error in the identus-…

### DIFF
--- a/docs/sdk/modules/Pluto.md
+++ b/docs/sdk/modules/Pluto.md
@@ -6,7 +6,7 @@ Pluto implementation
 
 Structure:
 - Pluto class is an orchestration layer
-- Repositories handle mapping Domain <-> Storable Models
+- Repositories handle mapping Domain `<->` Storable Models
 - Models suggest db structure
 - Store abstracts db implementation
 


### PR DESCRIPTION
…docs project

### Description: 
The char sequences `<->` failed the build of the identus-docs project
Link to the log: https://github.com/hyperledger/identus-docs/actions/runs/9858955881/job/27221527588?pr=135#step:6:14

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
