### PR TITLE
docs: link pluto-encrypted as reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ npm run start
 ```
 
 ### Implementing storage for the SDK
-This SDK exposes Pluto, a storage interface that should be implemented by the user, in the most appropriate way for a particular use case.
+This SDK exposes Pluto, which manages data schemas, migrations for you, but requires a Pluto.Store which needs to be implemented by the user, as this is particular to your use case.
 
-We don't provide a default implementation out of the box at the moment, but we do provide a couple of demo implementations that can be used to get started with demos and testing. 
+Provided demo implementations are intentionally oversimplified and **should not** be used in production.
 
-Provided demo implementations are intentionally oversimplified and **should not** be used in production. 
+Example community implementations:
+- [atala-community-projects/pluto-encrypted](https://github.com/atala-community-projects/pluto-encrypted): InMemory, IndexDB, LevelDB, as well as a test-suite to help you build your own.
+
 


### PR DESCRIPTION
### Description: 
The current README gives very little info on what's needed for a Pluto implementation

Changes:
- mentioned that it's Pluto.Store you need to implement (not Pluto any more)
- started a "community implementations" section, and linked `pluto-encrypted` work

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
