### PR TITLE
fix: generate docs after releasing as we cannot access a package that…

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -12,9 +12,8 @@ release_version="$1"
 # Updates the version to the release
 npm version "$release_version" --git-tag-version false
 
-# Generates the build and docs
+# Generates the build 
 npm run build
-npm run docs
 
 # Gets the published versions in the registry
 published_versions=$(echo "$(npm view @hyperledger/identus-edge-agent-sdk versions)" | tr -d " '")
@@ -28,3 +27,7 @@ if [[ $published_versions == *$release_version* ]]; then
 else
     npm publish --access public
 fi
+
+
+# Build docs
+npm run docs


### PR DESCRIPTION


### Description: 
generate docs after releasing as we cannot access a package that does not exist yet

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
