### PR TITLE
fix: improve didcomm error handling through Mercury and edge agent he…

### DIFF
--- a/src/edge-agent/helpers/ApiImpl.ts
+++ b/src/edge-agent/helpers/ApiImpl.ts
@@ -19,32 +19,33 @@ export class ApiImpl implements Api {
     httpHeaders: Map<string, string>,
     body?: any
   ): Promise<HttpResponse<T>> {
-    const rawUrl = new URL(`${url}`);
-    const rawHeaders: RawAxiosRequestHeaders = {};
-    for (const [name, value] of urlParameters) {
-      rawUrl.searchParams.append(name, value);
-    }
-
-    for (const [name, value] of httpHeaders) {
-      rawHeaders[name] = value;
-    }
-
-    const requestConfig: AxiosRequestConfig = {
-      baseURL: rawUrl.origin.toString(),
-      url: rawUrl.pathname,
-      method: httpMethod,
-      headers: rawHeaders,
-      validateStatus: function (status) {
-        return status >= 200 && status < 400;
-      },
-    };
-
-    if (body) {
-      requestConfig.data = body;
-    }
 
     // eslint-disable-next-line no-useless-catch
     try {
+      const rawUrl = new URL(`${url}`);
+      const rawHeaders: RawAxiosRequestHeaders = {};
+      for (const [name, value] of urlParameters) {
+        rawUrl.searchParams.append(name, value);
+      }
+
+      for (const [name, value] of httpHeaders) {
+        rawHeaders[name] = value;
+      }
+
+      const requestConfig: AxiosRequestConfig = {
+        baseURL: rawUrl.origin.toString(),
+        url: rawUrl.pathname,
+        method: httpMethod,
+        headers: rawHeaders,
+        validateStatus: function (status) {
+          return status >= 200 && status < 400;
+        },
+      };
+
+      if (body) {
+        requestConfig.data = body;
+      }
+
       const response = await this.client.request<T>(requestConfig);
 
       if (

--- a/src/mercury/Mercury.ts
+++ b/src/mercury/Mercury.ts
@@ -177,8 +177,13 @@ export default class Mercury implements MercuryInterface {
   private getDIDCommURL(document: Domain.DIDDocument): URL | undefined {
     const uri = document.services.find((x) => x.isDIDCommMessaging)
       ?.serviceEndpoint?.uri;
+
     if (uri) {
-      return new URL(uri);
+      try {
+        return new URL(uri);
+      } catch (err) {
+        throw new MercuryError.InvalidURLError('Invalid didcomm url')
+      }
     }
     return undefined;
   }


### PR DESCRIPTION

### Description: 
Improves error handling for didcomm messages when the mediator url is invalid.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
