### PR TITLE
fix: use for-loops in Pluto persistence methods

### DIFF
--- a/src/pluto/Pluto.ts
+++ b/src/pluto/Pluto.ts
@@ -198,19 +198,14 @@ export class Pluto implements Domain.Pluto {
 
   async storeDID(did: Domain.DID, keys?: Arrayable<Domain.PrivateKey>, alias?: string): Promise<void> {
     await this.Repositories.DIDs.save(did, alias);
-    await Promise.all(
-      asArray(keys).map(async key => {
-        await this.Repositories.Keys.save(key);
-
-        await this.Repositories.DIDKeyLinks.insert({
-          alias,
-          didId: did.uuid,
-          keyId: key.uuid
-        });
-      })
-    );
-
-
+    for (let key of asArray(keys)) {
+      await this.Repositories.Keys.save(key);
+      await this.Repositories.DIDKeyLinks.insert({
+        alias,
+        didId: did.uuid,
+        keyId: key.uuid
+      });
+    };
   }
 
   /** Prism DIDs **/
@@ -258,11 +253,10 @@ export class Pluto implements Domain.Pluto {
 
   async storePeerDID(did: Domain.DID, privateKeys: Domain.PrivateKey[]): Promise<void> {
     await this.Repositories.DIDs.save(did);
-    await Promise.all(privateKeys.map(x => this.Repositories.Keys.save(x)));
-
-    await Promise.all(
-      privateKeys.map(x => this.Repositories.DIDKeyLinks.insert({ didId: did.uuid, keyId: x.uuid }))
-    );
+    for (let key of privateKeys) {
+      await this.Repositories.Keys.save(key);
+      await this.Repositories.DIDKeyLinks.insert({ didId: did.uuid, keyId: key.uuid });
+    };
   }
 
   async getAllPeerDIDs(): Promise<PeerDID[]> {
@@ -301,7 +295,9 @@ export class Pluto implements Domain.Pluto {
   }
 
   async storeMessages(messages: Domain.Message[]): Promise<void> {
-    await Promise.all(messages.map(x => this.Repositories.Messages.save(x)));
+    for (let msg of messages) {
+      await this.Repositories.Messages.save(msg);
+    }
   }
 
   async getMessage(id: string): Promise<Domain.Message | null> {


### PR DESCRIPTION
### Description: 

We were seeing a problem with `@pluto-encrypted/leveldb` where 2 did-key links were persisted, but on recall we were only getting one back. We traced this down to a race-condition in the index updating, and so to `Promise.all` which calls in quick succession 2 updates to Pluto.Store index, so that one immediately overwrites the other.

### Alternatives Considered (optional): 

What's needed is some sort of "lock" on the updating of indexes. We considered 2 options:
1. modify `@pluto-encrypted/leveldb` to add a "queue" to the update index call so that it's safe to hammer it
2. modify the Pluto.Store code to run more in series with it's writes

We opted for (2) because:
- the write times involved are imperceptible to humans
- we want to avoid other developers falling in this exact same hole when they implement their own store
  - there needs to be a queue somewhere in the stack, may as well put it here so it doesn't need to be re-implemented multiple times


### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
