### PR TITLE
fix: main branchname in semantic release config

### DIFF
--- a/release-dev.config.js
+++ b/release-dev.config.js
@@ -1,10 +1,10 @@
 const baseConfig = require('./release.base.config');
 module.exports = baseConfig({
-    branches: [
-        'master',
-        {
-            name: 'release/*',
-            prerelease: 'rc'
-        }
-    ],
+  branches: [
+    'main',
+    {
+      name: 'release/*',
+      prerelease: 'rc'
+    }
+  ],
 });

--- a/release-prod.config.js
+++ b/release-prod.config.js
@@ -1,9 +1,9 @@
 const baseConfig = require('./release.base.config');
 module.exports = baseConfig({
-    branches: [
-        'master',
-        {
-            name: 'release/*',
-        }
-    ],
+  branches: [
+    'main',
+    {
+      name: 'release/*',
+    }
+  ],
 });


### PR DESCRIPTION
### Description: 
Semantic release config still referencing "master" branch.
Changed to "main"
