### PR TITLE
fix: e2e workflows misnamed package

### DIFF
--- a/integration-tests/e2e-tests/package.json
+++ b/integration-tests/e2e-tests/package.json
@@ -20,7 +20,7 @@
     "@amagyar-iohk/identus-cloud-agent-client-ts": "^1.36.1",
     "@cucumber/cucumber": "^10.3.1",
     "@cucumber/pretty-formatter": "^1.0.0",
-    "@hyperledger/identus-edge-agent-sdk": "../../hyperledger-identus-edge-agent-sdk-3.1.0.tgz",
+    "@hyperledger/identus-edge-agent-sdk": "../../",
     "@serenity-js/assertions": "^3.29.2",
     "@serenity-js/console-reporter": "^3.29.2",
     "@serenity-js/core": "^3.29.2",


### PR DESCRIPTION
e2e workflows are failing because tests package.json is pointing at a tarball that doesn't exist