### PR TITLE
fix: export Pluto models

### DIFF
--- a/src/pluto/rxdb/collections.ts
+++ b/src/pluto/rxdb/collections.ts
@@ -1,4 +1,4 @@
-import { MigrationStrategies, RxCollectionCreator, RxJsonSchema } from "rxdb";
+import { MigrationStrategies, RxJsonSchema } from "rxdb";
 import * as Models from "../models";
 import { Schema } from "../models/Schema";
 

--- a/src/pluto/rxdb/collections.ts
+++ b/src/pluto/rxdb/collections.ts
@@ -1,16 +1,30 @@
-import { RxCollectionCreator } from 'rxdb';
+import { MigrationStrategies, RxCollectionCreator, RxJsonSchema } from "rxdb";
 import * as Models from "../models";
+import { Schema } from "../models/Schema";
 
-export type CollectionList = Record<string, RxCollectionCreator>;
+type CollectionCreate<
+  RxDocType = any,
+  SchemaType extends Schema & RxJsonSchema<RxDocType> = Schema &
+  RxJsonSchema<RxDocType>
+> = {
+  schema: SchemaType;
+  migrationStrategies?:
+  | MigrationStrategies;
+};
 
-type MakeCollections = (additional?: CollectionList) => CollectionList
-export const makeCollections: MakeCollections = (additional: CollectionList = {}) => ({
-  "credentials": { schema: Models.CredentialSchema, migrationStrategies: Models.CredentialMigration },
+type MakeCollections = (additional?: CollectionList) => CollectionList;
+
+export type CollectionList = Record<string, CollectionCreate>;
+
+export const makeCollections: MakeCollections = (
+  additional: CollectionList = {}
+) => ({
+  credentials: { schema: Models.CredentialSchema, migrationStrategies: Models.CredentialMigration },
   "credential-metadata": { schema: Models.CredentialMetadataSchema },
   "didkey-link": { schema: Models.DIDKeyLinkSchema },
   "did-link": { schema: Models.DIDLinkSchema },
-  "dids": { schema: Models.DIDSchema },
-  "keys": { schema: Models.KeySchema },
-  "messages": { schema: Models.MessageSchema },
-  ...(additional),
+  dids: { schema: Models.DIDSchema },
+  keys: { schema: Models.KeySchema },
+  messages: { schema: Models.MessageSchema },
+  ...additional,
 });

--- a/src/pluto/rxdb/index.ts
+++ b/src/pluto/rxdb/index.ts
@@ -1,1 +1,3 @@
 export { RxdbStore as Store } from "./Store";
+export { makeCollections } from "./collections";
+export type { CollectionList } from "./collections";


### PR DESCRIPTION
### Description: 
exporting **Pluto** models to make them available outside SDK and make it easier to implement a compatible store.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
