### PR TITLE
fix: didcomm message body parsing and e2e tests for sd-jwt

### DIFF
--- a/integration-tests/e2e-tests/package.json
+++ b/integration-tests/e2e-tests/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/input-output-hk/atala-prism-wallet-sdk-ts-e2e",
   "dependencies": {
-    "@amagyar-iohk/identus-cloud-agent-client-ts": "^1.36.1",
+    "@amagyar-iohk/identus-cloud-agent-client-ts": "^1.40.1-b791ad2",
     "@cucumber/cucumber": "^10.3.1",
     "@cucumber/pretty-formatter": "^1.0.0",
     "@hyperledger/identus-edge-agent-sdk": "../../",

--- a/integration-tests/e2e-tests/src/steps/EdgeAgentSteps.ts
+++ b/integration-tests/e2e-tests/src/steps/EdgeAgentSteps.ts
@@ -268,9 +268,9 @@ Then("{actor} will request {actor} to verify the SD+JWT credential",
     const SDK = await EdgeAgentWorkflow.instance
     await EdgeAgentWorkflow.createPeerDids(holderEdgeAgent, 1)
     const holderDID = await holderEdgeAgent.answer(Notepad.notes().get("lastPeerDID"))
-    const claims: any = {
+    const claims = {
       claims: {
-        automationRequired: {
+        "automation-required": {
           type: "string",
           pattern: "required value"
         }

--- a/integration-tests/e2e-tests/src/workflow/CloudAgentWorkflow.ts
+++ b/integration-tests/e2e-tests/src/workflow/CloudAgentWorkflow.ts
@@ -98,9 +98,9 @@ export class CloudAgentWorkflow {
     const credential = new CreateIssueCredentialRecordRequest()
     credential.validityPeriod = 360000
     credential.claims = {
-      "automationRequired": "required value",
+      "automation-required": "required value",
     }
-    credential.schemaId = `${CloudAgentConfiguration.agentUrl}schema-registry/schemas/${CloudAgentConfiguration.jwtSchemaGuid}`
+    credential.schemaId = `${CloudAgentConfiguration.agentUrl}schema-registry/schemas/${CloudAgentConfiguration.sdJWTSchemaGuid}`
     credential.automaticIssuance = true
     credential.issuingDID = CloudAgentConfiguration.publishedEd25519Did
     credential.connectionId = await cloudAgent.answer<string>(

--- a/integration-tests/e2e-tests/src/workflow/CloudAgentWorkflow.ts
+++ b/integration-tests/e2e-tests/src/workflow/CloudAgentWorkflow.ts
@@ -100,6 +100,7 @@ export class CloudAgentWorkflow {
     credential.claims = {
       "automationRequired": "required value",
     }
+    credential.schemaId = `${CloudAgentConfiguration.agentUrl}schema-registry/schemas/${CloudAgentConfiguration.jwtSchemaGuid}`
     credential.automaticIssuance = true
     credential.issuingDID = CloudAgentConfiguration.publishedEd25519Did
     credential.connectionId = await cloudAgent.answer<string>(

--- a/src/edge-agent/helpers/ProtocolHelpers.ts
+++ b/src/edge-agent/helpers/ProtocolHelpers.ts
@@ -74,7 +74,8 @@ export const parseProblemReportBody = (msg: Message): ProblemReportBody => {
 }
 
 export const parseCredentialBody = (msg: Message): CredentialBody => {
-  if (Object.keys(msg.body).length === 0) {
+  if (!msg.body) {
+    //TODO: The body might be empty, but it should not be undefined according to the spec
     throw new AgentError.InvalidCredentialBodyError(
       "Invalid CredentialBody Error"
     );
@@ -86,8 +87,8 @@ export const parseCredentialBody = (msg: Message): CredentialBody => {
 
   return {
     formats: asArray(msg.body.formats).map(x => parseCredentialFormat(x)),
-    goalCode: msg.body.goalCode,
-    comment: msg.body.comment,
+    goalCode: msg.body.goalCode ?? null,
+    comment: msg.body.comment ?? null,
   };
 };
 


### PR DESCRIPTION
### Description: 
- Fixed the parsing logic of the `body` field in the DIDComm protocol
- Fixed the steps in SD_JWT issuance logic (added schemaId)

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
