### PR TITLE
chore: fix documentation main package and fix castor verifySignature …

### DIFF
--- a/src/castor/Castor.ts
+++ b/src/castor/Castor.ts
@@ -392,17 +392,23 @@ export default class Castor implements CastorInterface {
    * ```ts
    * const message = "data to sign";
    * const messageBytes = new TextEncoder().encode(message);
-   * const signatureSecp256K1 = apollo.signStringMessage(keyPairSecp256K1.privateKey, message);
-   *
-   * const did = castor.parseDID("did:prism:123456");
-   * const challenge = messageBytes
-   * const signature = signatureSecp256K1.value;
-   *
-   * const isValid = castor.verifySignature(
-   *     castor.parseDID("did:prism:123456"),
-   *     challenge, // Uint8Array
-   *     signature // Uint8Array
-   * );
+   * const {mnemonics, seed} = apollo.createRandomSeed();
+   * const privateKey = apollo.createPublicKey({
+   *   type: KeyTypes.EC,
+   *   curve: Curve.SECP256K1,
+   *   seed: Buffer.from(seed.value).toString("hex"),
+   *   derivationPath: "m/0'/0'/0'"
+   * });
+   * if (privateKey.isSignable()) {
+   *   const signature = privateKey.sign(message);
+   *   const did = castor.parseDID("did:prism:123456");
+   *   const challenge = messageBytes
+   *   const isValid = castor.verifySignature(
+   *       castor.parseDID("did:prism:123456"),
+   *       challenge, // Uint8Array
+   *       signature // Uint8Array
+   *   );
+   * }
    * ```
    *
    * @async

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,3 +1,5 @@
+const packageJson = require("./package.json");
+
 module.exports = {
     "$schema": "https://typedoc.org/schema.json",
     "entryPoints": [
@@ -5,7 +7,7 @@ module.exports = {
     ],
     "out": "./docs/sdk",
     "tsconfig": "./tsconfig.json",
-    "name": "@atala/prism-wallet-sdk",
+    "name": packageJson.name,
     "useTsLinkResolution": true,
     "hideGenerator": true,
     "entryPointStrategy": "resolve",


### PR DESCRIPTION

### Description: 
Small docs improvement. We have changed the typedoc namespace to be @hyperledger/identus-edge-agent-sdk, whatever is in the main package json, we will no longer have this issue (wrong namespace pointing to @atala)

Also made a small fix into Castor verifySignature method that was showing code prior to the cryptographic abstraction epic and is now showing a valid code example.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
