### PR TITLE
fix: release issue with trusted publishing on npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ steps.import_gpg.outputs.email }}
           GIT_COMMITTER_EMAIL: ${{ steps.import_gpg.outputs.email }}
           GIT_AUTHOR_NAME: ${{ steps.import_gpg.outputs.name }}

--- a/release.config.js
+++ b/release.config.js
@@ -32,7 +32,7 @@ module.exports = {
     ['@semantic-release/commit-analyzer', { preset: "conventionalcommits" }],
     ['@semantic-release/exec', { "prepareCmd": 'npm version ${nextRelease.version} --git-tag-version false' }],
     ['@semantic-release/exec', { "prepareCmd": 'npm run build' }],
-    ['@semantic-release/exec', { "publishCmd": 'npm publish --tag ${nextRelease.channel || "latest"} --access public' }],
+    ['@semantic-release/exec', { "publishCmd": 'npm publish --tag ${nextRelease.channel || "latest"} --access public --provenance' }],
     ...plugins
   ],
 };


### PR DESCRIPTION
### Description: 
Followed official npm documentation [[HERE]](https://docs.npmjs.com/generating-provenance-statements) To properly enable trusted publishing on npm

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
