### PR TITLE
chore: update wasm-pack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repository also includes a browser and a Node.js demo application
 #### Build demo dependencies
 The demos assume building this repo from source, so you will need the following:
 * Bash
-* Rust ([cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html)) and [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) installed.
+* Rust ([cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html)) and [wasm-pack](https://drager.github.io/wasm-pack/) installed.
 * Node JS Version (20/LTS Recommended)
 
 Clone and build:


### PR DESCRIPTION
### Description: 

> The Rust and WebAssembly Working Group was [created in 2018](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018/) as part of the initiative for the 2018 edition at the time. Through 2019 the working group was quite active and helped Rust's support for WebAssembly flourish. Tools such as [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen) and [wasm-pack](https://github.com/rustwasm/wasm-pack) were created as part of this effort and continue to be used to this day. After 2019 though the organization saw a drastic reduction in activity and most projects have been in maintenance mode for nearly 5 years at this point.

https://blog.rust-lang.org/inside-rust/2025/07/21/sunsetting-the-rustwasm-github-org/


https://github.com/hyperledger-identus/sdk-ts/issues/475


### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
