### PR TITLE
chore(lint): Introduce new linting base rules, not yet in use but to …

### DIFF
--- a/eslint.base.mjs
+++ b/eslint.base.mjs
@@ -1,0 +1,134 @@
+import tseslint from "typescript-eslint";
+import js from "@eslint/js";
+
+// ─── Production-ready rule tiers ───────────────────────────────────────────
+// ERROR  = blocks CI — critical safety/correctness
+// WARN   = surfaces issues — promote to error as violations are cleaned up
+// OFF    = intentionally disabled (with documented reason)
+
+/** Error-level rules: critical safety and correctness */
+const errorRules = {
+    // JS safety
+    "no-debugger": "error",
+    "no-const-assign": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-unreachable": "error",
+    "no-self-assign": "error",
+    "no-self-compare": "error",
+
+    // TS async safety (type-checked)
+    "@typescript-eslint/no-misused-promises": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/await-thenable": "error",
+
+    // Module consistency
+    "@typescript-eslint/no-require-imports": "error",
+};
+
+/** Warn-level rules: code quality, promote to error over time */
+const warnRules = {
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+            argsIgnorePattern: "^_",
+            varsIgnorePattern: "^_",
+            caughtErrorsIgnorePattern: "^_",
+        },
+    ],
+    "@typescript-eslint/ban-ts-comment": [
+        "warn",
+        {
+            "ts-expect-error": "allow-with-description",
+            "ts-ignore": true,
+            "ts-nocheck": true,
+            "ts-check": false,
+        },
+    ],
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "@typescript-eslint/consistent-type-imports": [
+        "warn",
+        { prefer: "type-imports", fixStyle: "inline-type-imports" },
+    ],
+    "@typescript-eslint/no-empty-object-type": "warn",
+    "no-console": "warn",
+    // Downgraded from recommendedTypeChecked (these fire everywhere `any` is used)
+    "@typescript-eslint/no-unsafe-argument": "warn",
+    "@typescript-eslint/no-unsafe-assignment": "warn",
+    "@typescript-eslint/no-unsafe-call": "warn",
+    "@typescript-eslint/no-unsafe-member-access": "warn",
+    "@typescript-eslint/no-unsafe-return": "warn",
+    "@typescript-eslint/no-redundant-type-constituents": "warn",
+    "no-empty": "warn",
+};
+
+/** Intentionally disabled rules (with reasons) */
+const offRules = {
+    // Project uses namespaces by design (Domain layer)
+    "@typescript-eslint/no-namespace": "off",
+    // Handled by TypeScript itself
+    "no-redeclare": "off",
+    // Too noisy for this codebase
+    "@typescript-eslint/explicit-function-return-type": "off",
+    // Covered by @typescript-eslint/no-unused-vars
+    "no-unused-vars": "off",
+    // TypeScript handles this
+    "no-undef": "off",
+};
+
+/** Combined production rule set — exported for sub-package reuse */
+export const productionRules = {
+    ...errorRules,
+    ...warnRules,
+    ...offRules,
+};
+
+/** Common ignores — exported for sub-package reuse */
+export const commonIgnores = [
+    "**/dist/**",
+    "**/build/**",
+    "**/node_modules/**",
+    "**/coverage/**",
+    "**/*.d.ts",
+    "**/generated/**",
+];
+
+/**
+ * Helper to create a type-checked ESLint config scoped to source files.
+ * Use this in sub-packages:
+ *   import { createPackageConfig } from "../../../eslint.config.mjs";
+ *   export default createPackageConfig(import.meta.dirname);
+ */
+export function createPackageConfig(dirname, extraIgnores = [], extraRules = {}) {
+    return tseslint.config(
+        { ignores: [...commonIgnores, ...extraIgnores] },
+
+        // Type-checked TS rules scoped to source files only
+        {
+            files: ["src/**/*.ts", "src/**/*.tsx"],
+            extends: [
+                js.configs.recommended,
+                ...tseslint.configs.recommendedTypeChecked,
+            ],
+            languageOptions: {
+                parserOptions: {
+                    ecmaVersion: "latest",
+                    sourceType: "module",
+                    projectService: true,
+                    tsconfigRootDir: dirname,
+                },
+            },
+            rules: {
+                ...productionRules,
+                ...extraRules,
+            },
+        },
+    );
+}
+
+export default createPackageConfig(import.meta.dirname, [
+    "externals/**",
+    "integration-tests/**",
+    "src/castor/protos/**",
+]);


### PR DESCRIPTION
…refactor SDK in batches.

### Description: 
Adds base linting rules, nothing else, for [ISSUE](https://github.com/hyperledger-identus/sdk-ts/issues/500), this will enable us linting both sdk and e2e tests

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
