### PR TITLE
fix: expo compatibility fix, using initSync, remove sed hardcoding

### DIFF
--- a/externals/run.sh
+++ b/externals/run.sh
@@ -53,12 +53,10 @@ buildDIDComm() {
   fi
   if is_mac; then
     sed -i '' 's/"module": "identus-didcomm.js",/"main": "identus-didcomm.js",/' package.json;
-    sed -i '' "/if (typeof input === 'undefined') {/,/}/d" "./identus-didcomm.js";
-    sed -i '' "/if (typeof module_or_path === 'undefined') {/,/}/d" "./identus-didcomm.js";
+    sed -i '' '/new URL.*_bg\.wasm/d' "./identus-didcomm.js";
   else
     sed -i 's/"module": "identus-didcomm.js",/"main": "identus-didcomm.js",/' package.json;
-    sed -i "/if (typeof input === 'undefined') {/,/}/d" "./identus-didcomm.js";
-    sed -i "/if (typeof module_or_path === 'undefined') {/,/}/d" "./identus-didcomm.js";
+    sed -i '/new URL.*_bg\.wasm/d' "./identus-didcomm.js";
   fi
   cd $ExternalsDir
   git submodule | grep $DIDCommSrc | awk '{print $1}' > "./${DIDCommOut}.commit"
@@ -82,12 +80,10 @@ buildJWT() {
   fi
   if is_mac; then
     sed -i '' 's/"module": "identus-jwe.js",/"main": "identus-jwe.js",/' package.json;
-    sed -i '' "/if (typeof input === 'undefined') {/,/}/d" identus-jwe.js;
-    sed -i '' "/if (typeof module_or_path === 'undefined') {/,/}/d" identus-jwe.js;
+    sed -i '' '/new URL.*_bg\.wasm/d' identus-jwe.js;
   else
     sed -i 's/"module": "identus-jwe.js",/"main": "identus-jwe.js",/' package.json;
-    sed -i "/if (typeof input === 'undefined') {/,/}/d" identus-jwe.js;
-    sed -i "/if (typeof module_or_path === 'undefined') {/,/}/d" identus-jwe.js;
+    sed -i '/new URL.*_bg\.wasm/d' identus-jwe.js;
   fi
 
   cd $ExternalsDir
@@ -116,12 +112,10 @@ buildAnonCreds() {
   fi
   if is_mac; then
     sed -i '' 's/"module": "identus-anoncreds.js",/"main": "identus-anoncreds.js",/' package.json;
-    sed -i '' "/if (typeof input === 'undefined') {/,/}/d" "./identus-anoncreds.js";
-    sed -i '' "/if (typeof module_or_path === 'undefined') {/,/}/d" "./identus-anoncreds.js";
+    sed -i '' '/new URL.*_bg\.wasm/d' "./identus-anoncreds.js";
   else
     sed -i 's/"module": "identus-anoncreds.js",/"main": "identus-anoncreds.js",/' package.json;
-    sed -i "/if (typeof input === 'undefined') {/,/}/d" "./identus-anoncreds.js";
-    sed -i "/if (typeof module_or_path === 'undefined') {/,/}/d" "./identus-anoncreds.js";
+    sed -i '/new URL.*_bg\.wasm/d' "./identus-anoncreds.js";
   fi
 
   cd $ExternalsDir

--- a/packages/lib/sdk/package.json
+++ b/packages/lib/sdk/package.json
@@ -77,7 +77,6 @@
     "last 2 edge version"
   ],
   "scripts": {
-    "prepare": "npx husky",
     "lint": "npx eslint ."
   },
   "author": "IOHK",
@@ -91,7 +90,6 @@
     "@types/jsonld": "^1.5.14",
     "@types/node": "^22",
     "@types/pako": "^2.0.3",
-    "husky": "^9.0.11",
     "jsdom": "^24.1.0",
     "prettier": "^3.5.3",
     "protoc-gen-ts": "^0.8.7",
@@ -112,8 +110,8 @@
     "@sinclair/typebox": "^0.32.31",
     "@stablelib/sha256": "^1.0.1",
     "@stablelib/uuid": "^1.0.2",
-    "@trust0/ridb": "^1.5.44",
-    "@trust0/ridb-core": "^1.7.39",
+    "@trust0/ridb": "^1.5.45",
+    "@trust0/ridb-core": "^1.7.40",
     "bn.js": "^5.2.1",
     "did-jwt": "^8.0.4",
     "did-resolver": "^4.1.0",

--- a/packages/lib/sdk/tsup.config.ts
+++ b/packages/lib/sdk/tsup.config.ts
@@ -1,10 +1,5 @@
 import { defineConfig } from 'tsup'
 
-const ESM_REQUIRE_SHIM = `
-import { createRequire as __$$createRequire } from 'module';
-const require = __$$createRequire(import.meta.url);
-`.trim();
-
 export default defineConfig({
   entry: [
     'src/index.ts',
@@ -22,12 +17,9 @@ export default defineConfig({
   loader: {
     '.wasm': 'binary'
   },
-  // Inject createRequire shim only in ESM output so bundled CJS deps
-  // (e.g. @stablelib/random → require("crypto")) work in Node ESM.
-  banner: (ctx) => ctx.format === 'esm' ? { js: ESM_REQUIRE_SHIM } : {},
   external: ['buffer', 'crypto', 'node:crypto', 'node:buffer'],
-  minifyWhitespace: true,
-  minifyIdentifiers: true,
+  minifyWhitespace: false,
+  minifyIdentifiers: false,
   minifySyntax: false,
   shims: true,
   noExternal: [

--- a/packages/lib/sdk/tsup.config.ts
+++ b/packages/lib/sdk/tsup.config.ts
@@ -18,8 +18,8 @@ export default defineConfig({
     '.wasm': 'binary'
   },
   external: ['buffer', 'crypto', 'node:crypto', 'node:buffer'],
-  minifyWhitespace: false,
-  minifyIdentifiers: false,
+  minifyWhitespace: true,
+  minifyIdentifiers: true,
   minifySyntax: false,
   shims: true,
   noExternal: [

--- a/packages/wasm/anoncreds/src/index.ts
+++ b/packages/wasm/anoncreds/src/index.ts
@@ -1,4 +1,4 @@
-import type * as Anoncreds from "@hyperledger/identus-anoncreds-wasm";
+import * as Anoncreds from "@hyperledger/identus-anoncreds-wasm";
 // @ts-ignore
 import wasmBuffer from '@hyperledger/identus-anoncreds-wasm/identus-anoncreds_bg.wasm';
 
@@ -29,11 +29,10 @@ export class AnoncredsLoader {
     }
 
     private async load() {
-        this.pkg ??= await import("@hyperledger/identus-anoncreds-wasm").then(async module => {
-            const wasmInstance = module.initSync({ module: wasmBuffer });
-            await module.default(wasmInstance);
-            return module;
-        });
+        if (!this.pkg) {
+            Anoncreds.initSync({ module: wasmBuffer });
+            this.pkg = Anoncreds;
+        }
     }
 
     private async wasm() {

--- a/packages/wasm/anoncreds/tsconfig.test.json
+++ b/packages/wasm/anoncreds/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
   "include": [
     "src/**/*.ts",
     "tests/**/*.ts"

--- a/packages/wasm/config/tsup.config.ts
+++ b/packages/wasm/config/tsup.config.ts
@@ -4,6 +4,36 @@ import { type Options } from 'tsup'
 import type { Plugin } from 'esbuild'
 
 /**
+ * esbuild plugin to strip `new URL("*_bg.wasm", import.meta.url)` references
+ * from wasm-bindgen generated JS files.
+ *
+ * esbuild cannot tree-shake the async `default` export (__wbg_init) that
+ * contains this URL reference. If left in, downstream bundlers (Metro, webpack)
+ * try to resolve the .wasm file at build time and fail.
+ *
+ * We replace the URL constructor call with `undefined` so the dead code
+ * path is harmless.
+ */
+function wasmUrlStripPlugin(): Plugin {
+  return {
+    name: 'strip-wasm-url',
+    setup(build) {
+      build.onLoad({ filter: /\.js$/ }, async (args) => {
+        // Only process wasm-bindgen generated files in the generated directory
+        if (!args.path.includes('generated')) return undefined
+        const source = await fs.promises.readFile(args.path, 'utf-8')
+        if (!source.includes('_bg.wasm')) return undefined
+        const stripped = source.replace(
+          /new URL\(["'][^"']*_bg\.wasm["'],\s*import\.meta\.url\)/g,
+          'undefined'
+        )
+        return { contents: stripped, loader: 'js' }
+      })
+    },
+  }
+}
+
+/**
  * esbuild plugin to resolve @hyperledger/identus-* imports
  * to the generated wasm packages (tsconfig paths don't work in esbuild)
  */
@@ -79,7 +109,7 @@ export function createWasmTsupConfig(aliasName: string, projectDir: string): Opt
     sourcemap: true,
     skipNodeModulesBundle: false,
     loader: { '.wasm': 'binary' },
-    esbuildPlugins: [wasmPackagesPlugin(aliasName, generatedDir)],
+    esbuildPlugins: [wasmUrlStripPlugin(), wasmPackagesPlugin(aliasName, generatedDir)],
     external: ['buffer'],
     minifyWhitespace: true,
     minifyIdentifiers: true,

--- a/packages/wasm/didcomm/tsconfig.test.json
+++ b/packages/wasm/didcomm/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
   "include": [
     "src/**/*.ts",
     "tests/**/*.ts"

--- a/packages/wasm/jwe/src/index.ts
+++ b/packages/wasm/jwe/src/index.ts
@@ -1,24 +1,21 @@
 import type * as JWEModule from "@hyperledger/identus-jwe-wasm";
 // @ts-ignore – binary loader inlines the .wasm as a Buffer at build time
 import jweWasm from "@hyperledger/identus-jwe-wasm/identus-jwe_bg.wasm";
+import { initSync, JWE } from "@hyperledger/identus-jwe-wasm";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-let jwe: typeof import("@hyperledger/identus-jwe-wasm") | undefined;
+let initialized = false;
 
 /**
  * Lazily initialise the JWE WASM module (singleton).
- * Uses `initSync` + `default` to compile the embedded WASM buffer once,
+ * Uses `initSync` to compile the embedded WASM buffer once,
  * then caches the module for subsequent calls.
  */
 export async function getJWE(): Promise<typeof JWEModule.JWE> {
-  if (jwe === undefined) {
-    jwe = await import("@hyperledger/identus-jwe-wasm").then(async (module) => {
-      const wasmInstance = module.initSync({ module: jweWasm });
-      await module.default(wasmInstance);
-      return module;
-    });
+  if (!initialized) {
+    initSync({ module: jweWasm });
+    initialized = true;
   }
-  return jwe!.JWE;
+  return JWE;
 }
 
 // Re-export WASM types for downstream consumers

--- a/packages/wasm/jwe/tsconfig.test.json
+++ b/packages/wasm/jwe/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
   "include": [
     "src/**/*.ts",
     "tests/**/*.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,8 +1930,8 @@ __metadata:
     "@sinclair/typebox": "npm:^0.32.31"
     "@stablelib/sha256": "npm:^1.0.1"
     "@stablelib/uuid": "npm:^1.0.2"
-    "@trust0/ridb": "npm:^1.5.44"
-    "@trust0/ridb-core": "npm:^1.7.39"
+    "@trust0/ridb": "npm:^1.5.45"
+    "@trust0/ridb-core": "npm:^1.7.40"
     "@types/jsonld": "npm:^1.5.14"
     "@types/node": "npm:^22"
     "@types/pako": "npm:^2.0.3"
@@ -1940,7 +1940,6 @@ __metadata:
     did-resolver: "npm:^4.1.0"
     google-protobuf: "npm:^3.21.2"
     hash.js: "npm:1.1.7"
-    husky: "npm:^9.0.11"
     isows: "npm:^1.0.3"
     jsdom: "npm:^24.1.0"
     jsonld: "npm:^9.0.0"
@@ -3357,19 +3356,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trust0/ridb-core@npm:1.7.39, @trust0/ridb-core@npm:^1.7.39":
-  version: 1.7.39
-  resolution: "@trust0/ridb-core@npm:1.7.39"
-  checksum: 10c0/df31fab1b829b28bf34c4b794342010edae5e717e9855c9a0a989f1c6cfd232cf17426103f6731a70ede15392527104788fa32daeb83395338c49fe8419eee0c
+"@trust0/ridb-core@npm:1.7.40, @trust0/ridb-core@npm:^1.7.40":
+  version: 1.7.40
+  resolution: "@trust0/ridb-core@npm:1.7.40"
+  checksum: 10c0/c4bdd23c35753bf9ff95f788a0b8f4f3b032c54f0bfc79e959ffee93d6cc3ec523b2f1db530daecdf5c7f0188eb90bbfb8939c42310a903b0814c70abf4214e1
   languageName: node
   linkType: hard
 
-"@trust0/ridb@npm:^1.5.44":
-  version: 1.5.44
-  resolution: "@trust0/ridb@npm:1.5.44"
+"@trust0/ridb@npm:^1.5.45":
+  version: 1.5.45
+  resolution: "@trust0/ridb@npm:1.5.45"
   dependencies:
-    "@trust0/ridb-core": "npm:1.7.39"
-  checksum: 10c0/cc1a967a9c1e37651772512abaff8fe90832c904c5b5be9098d4cd9a698a9dff483f21299ec77b4a63c0e2e1cfc25a1751c540d758751412eb3b81523f974924
+    "@trust0/ridb-core": "npm:1.7.40"
+  checksum: 10c0/96836bcdbd2da2b5f6721a0517bf1cacdbc4e2fe59005e056658cb3f5da7fd8bb294727fbc5632c9a1ef4adb039d20238ff14e051616753bc281c779b956b08f
   languageName: node
   linkType: hard
 
@@ -6250,15 +6249,6 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
-  languageName: node
-  linkType: hard
-
-"husky@npm:^9.0.11":
-  version: 9.1.7
-  resolution: "husky@npm:9.1.7"
-  bin:
-    husky: bin.js
-  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

### Description: 
Make the package compatible with expo and react-native. 
Using the library in expo build crashes due to the way wasm files are consumed, we never identified this issue in the past.

We will from now on continue using wasms but load them differently. 
Applied the same improvements also to @trust0/ridb and @trust0/ridb-core

The code now builds on react-native + chrome extension with expo build


### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
