### PR TITLE
fix(build): updated dockerfile and readme for workspace structure

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -4,8 +4,8 @@ set -e
 # Navigate to the application directory
 cd /app
 
-# Install NPM dependencies
-npm install
+# Install dependencies using Yarn
+yarn install
 
 # Initialize Git repository if not present
 if [ ! -d ".git" ]; then
@@ -13,4 +13,4 @@ if [ ! -d ".git" ]; then
 fi
 
 # Run the build script
-npm run build
+yarn build

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ This still requires the .env var in ./integration-tests/e2e-tests/.env properly 
 yarn test
 ```
 
-If you have any issues while building you can try building from docker (this runs exaclty the same build):
+If you have any issues while building you can try building from docker (this runs exactly the same build):
 ```bash
-docker build -t atalaprismwalletsdkts:latest "." 
-docker run  -v $(pwd)/build:/app/build atalaprismwalletsdkts:latest
+docker build -t identus-sdk-ts:latest "." 
+docker run  -v $(pwd)/build:/app/build identus-sdk-ts:latest
 ```

--- a/dockerfile
+++ b/dockerfile
@@ -21,27 +21,33 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo install wasm-pack
 ENV WASM_BINDGEN_PATH="/root/.cargo/bin/wasm-bindgen"
 
+# Enable Corepack for Yarn
+RUN corepack enable
+
 # Set the working directory inside the container
 WORKDIR /app
 VOLUME /app/build
 
-# Copy package.json and package-lock.json
-# to leverage Docker cache
-COPY ./*.sh ./
-COPY package*.json ./
-COPY patches ./patches
+# Copy package manager and dependency files first to leverage Docker cache
+COPY package.json yarn.lock .yarnrc.yml ./
+
+# Copy workspace configuration
+COPY nx.json tsconfig.base.json ./
+COPY eslint.base.mjs eslint.config.mjs ./
+COPY vitest.base.config.mjs vitest.config.js ./
+COPY .gitmodules ./
+
+# Copy workspace packages
+COPY packages ./packages
 COPY externals ./externals
-COPY *.js ./
-COPY *.mjs ./
-COPY *.json ./
-COPY src ./src
+COPY integration-tests ./integration-tests
 
-
+# Initialize git (needed for submodules / git-based tooling)
 RUN git init
+
 # Install entrypoint script
 COPY ./.docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
 
 # Set the entrypoint
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -66,10 +66,10 @@ yarn
 npm run build
 ```
 
-If you have any issues while building you can try building from docker (this runs exaclty the same build):
+If you have any issues while building you can try building from docker (this runs exactly the same build):
 ```bash
-docker build -t atalaprismwalletsdkts:latest "." 
-docker run  -v $(pwd)/build:/app/build atalaprismwalletsdkts:latest
+docker build -t identus-sdk-ts:latest "." 
+docker run  -v $(pwd)/build:/app/build identus-sdk-ts:latest
 ```
 
 #### Run the demos


### PR DESCRIPTION
### Description: 
Fixes #515

The current Dockerfile references the old flat project structure (`COPY src ./src`, `COPY patches ./patches`) which no longer exists since the Nx workspace migration in v8.0.0.

**Changes:**
- **dockerfile**: Replaced the old flat `COPY` commands with workspace-aware copies (`packages/`, `integration-tests/`, config files). Add `corepack enable` for Yarn 4.x support.
- **.docker/entrypoint.sh**: Switch from `npm install`/`npm run build` to `yarn install`/`yarn build`
- **README.md**: Updated docker image name from `atalaprismwalletsdkts` to `identus-sdk-ts`, fix typo `exaclty` → `exactly`
- **docs/sdk/README.md**: Same docker section fix

### Alternatives Considered (optional): 
Copying the entire repo context with `COPY . .` was considered but rejected in favor of explicit copies to maintain better Docker layer caching.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/sdk-ts/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)