### PR TITLE
fix(castor): improve error message for unsupported PeerDID curve

### DIFF
--- a/packages/lib/sdk/src/castor/utils/index.ts
+++ b/packages/lib/sdk/src/castor/utils/index.ts
@@ -147,9 +147,12 @@ export async function computeEncnumbasis(
             material = authenticationFromPublicKey(publicKey);
             multibaseEcnumbasis = createMultibaseEncnumbasis(material);
             return multibaseEcnumbasis.slice(1);
-        default:
-            //TODO: Improve this error handling
-            throw new Error("computeEncnumbasis -> InvalidKeyPair Curve");
+        default: {
+            const currentCurve = publicKey.getProperty(Domain.KeyProperties.curve);
+            throw new Domain.CastorError.InvalidKeyError(
+                `Unsupported curve for PeerDID key derivation: ${currentCurve}. Supported curves: ${Domain.Curve.ED25519}, ${Domain.Curve.X25519}`
+            );
+        }
     }
 
 }

--- a/packages/lib/sdk/src/peer-did/PeerDIDCreate.ts
+++ b/packages/lib/sdk/src/peer-did/PeerDIDCreate.ts
@@ -86,11 +86,12 @@ export class PeerDIDCreate {
   }
 
   /**
-   * Computes Encnumbasis from a valid did and its keyPair
+   * Computes Encnumbasis from a valid did and its keyPair.
    *
    * @param {DID} did
    * @param {PublicKey} publicKey
    * @returns {string}
+   * @throws {CastorError.InvalidKeyError} if the public key curve is unsupported (only ED25519 and X25519 are supported)
    */
   computeEncnumbasis(did: DID, publicKey: PublicKey): string {
     let material:

--- a/packages/lib/sdk/src/peer-did/PeerDIDCreate.ts
+++ b/packages/lib/sdk/src/peer-did/PeerDIDCreate.ts
@@ -108,11 +108,12 @@ export class PeerDIDCreate {
         material = this.authenticationFromPublicKey(publicKey);
         multibaseEcnumbasis = this.createMultibaseEncnumbasis(material);
         return multibaseEcnumbasis.slice(1);
-      default:
+      default: {
         const currentCurve = publicKey.getProperty(KeyProperties.curve);
         throw new CastorError.InvalidKeyError(
           `Unsupported curve for PeerDID key derivation: ${currentCurve}. Supported curves: ${Curve.ED25519}, ${Curve.X25519}`
         );
+      }
     }
   }
 

--- a/packages/lib/sdk/src/peer-did/PeerDIDCreate.ts
+++ b/packages/lib/sdk/src/peer-did/PeerDIDCreate.ts
@@ -108,8 +108,10 @@ export class PeerDIDCreate {
         multibaseEcnumbasis = this.createMultibaseEncnumbasis(material);
         return multibaseEcnumbasis.slice(1);
       default:
-        //TODO: Improve this error handling
-        throw new Error("computeEncnumbasis -> InvalidKeyPair Curve");
+        const currentCurve = publicKey.getProperty(KeyProperties.curve);
+        throw new CastorError.InvalidKeyError(
+          `Unsupported curve for PeerDID key derivation: ${currentCurve}. Supported curves: ${Curve.ED25519}, ${Curve.X25519}`
+        );
     }
   }
 

--- a/packages/lib/sdk/tests/castor/PeerDID.test.ts
+++ b/packages/lib/sdk/tests/castor/PeerDID.test.ts
@@ -223,6 +223,10 @@ describe("PEERDID CreateTest", () => {
     }
   });
 
+  /**
+   * Verify that we properly throw a domain-specific InvalidKeyError
+   * when an unsupported curve is passed to getEcnumbasis.
+   */
   it("should throw InvalidKeyError for unsupported curve in getEcnumbasis", async () => {
     const apollo = new Apollo();
     const castor = new Castor(apollo);

--- a/packages/lib/sdk/tests/castor/PeerDID.test.ts
+++ b/packages/lib/sdk/tests/castor/PeerDID.test.ts
@@ -7,6 +7,7 @@ import {
   PublicKey,
   KeyTypes,
   Curve,
+  CastorError,
 } from '@hyperledger/identus-domain';
 import { Apollo } from "../../src/apollo";
 
@@ -220,5 +221,29 @@ describe("PEERDID CreateTest", () => {
 
       expect(result).to.be.equal(true);
     }
+  });
+
+  it("should throw InvalidKeyError for unsupported curve in getEcnumbasis", async () => {
+    const apollo = new Apollo();
+    const castor = new Castor(apollo);
+
+    // Create a key with SECP256K1 curve (not supported for PeerDID encnumbasis)
+    const seed = apollo.createRandomSeed().seed;
+    const unsupportedKey = apollo.createPrivateKey({
+      type: KeyTypes.EC,
+      curve: Curve.SECP256K1,
+      seed: Buffer.from(seed.value).toString("hex"),
+    });
+
+    // Create a valid PeerDID first (needed as first parameter)
+    const validKey = apollo.createPrivateKey({
+      type: KeyTypes.EC,
+      curve: Curve.ED25519,
+    });
+    const validDID = await castor.createPeerDID([validKey.publicKey()], []);
+
+    // Call getEcnumbasis directly - this hits computeEncnumbasis switch-case
+    expect(() => castor.getEcnumbasis(validDID, unsupportedKey.publicKey()))
+      .toThrow(CastorError.InvalidKeyError);
   });
 });

--- a/packages/lib/sdk/tests/castor/PeerDID.test.ts
+++ b/packages/lib/sdk/tests/castor/PeerDID.test.ts
@@ -7,6 +7,7 @@ import {
   PublicKey,
   KeyTypes,
   Curve,
+  CastorError,
 } from '@hyperledger/identus-domain';
 import { Apollo } from "../../src/apollo";
 
@@ -18,6 +19,7 @@ import {
 } from "@hyperledger/identus-domain";
 import { PeerDIDResolver } from "../../src/castor/resolver/PeerDIDResolver";
 import { MultiCodec } from '../../src/castor/utils/Multicodec';
+import { computeEncnumbasis } from '../../src/castor/utils';
 describe("PEERDID CreateTest", () => {
   it("Should test milticodec coding", () => {
     const testData = Uint8Array.from(Buffer.from("test1"));
@@ -238,5 +240,19 @@ describe("PEERDID CreateTest", () => {
 
       expect(result).to.be.equal(true);
     }
+  });
+
+  it("should throw InvalidKeyError for unsupported curve in computeEncnumbasis", async () => {
+    const apollo = new Apollo();
+
+    const seed = apollo.createRandomSeed().seed;
+    const unsupportedKey = await apollo.createPrivateKey({
+      type: KeyTypes.EC,
+      curve: Curve.SECP256K1,
+      seed: seed.value,
+    });
+
+    await expect(computeEncnumbasis(unsupportedKey.publicKey()))
+      .rejects.toThrow(CastorError.InvalidKeyError);
   });
 });


### PR DESCRIPTION
### Description
This PR fixes a confusing error message I spotted in `PeerDIDCreate.ts` (see Issue #532).  
Instead of the generic `Error`, unsupported curves now throw `CastorError.InvalidKeyError` with a clear message that lists the supported curves.  

I also added a unit test in `PeerDID.test.ts` to verify that `getEcnumbasis` correctly throws for unsupported curves like `SECP256K1`.  
This should make debugging much smoother for developers encountering this scenario.

**Related Issue:** Fixes #532  
**Note:** This is my first contribution to the SDK as part of the LFX 2026 Mentorship application.

### Alternatives Considered
I thought about just updating the error string, but following the existing `CastorError` pattern is cleaner and keeps the codebase consistent.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
