### PR TITLE
fix(pollux): JWT.verify does not check exp claim

### DIFF
--- a/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
@@ -61,6 +61,11 @@ export class JWT extends Task.Runner {
 
       const decoded = await this.decode(jws);
 
+      const exp = decoded.payload.exp;
+      if (typeof exp === "number" && Math.floor(Date.now() / 1000) > exp) {
+        return false;
+      }
+
       for (const verificationMethod of verificationMethods) {
         try {
           const pk = await this.runTask(new PKInstance({ verificationMethod }));

--- a/packages/lib/sdk/tests/pollux/JWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/JWT.test.ts
@@ -204,6 +204,47 @@ describe("Domain - JWT", () => {
 
       expect(result).toBe(false);
     });
+
+    describe("expiration", () => {
+      const privateKey = Fixtures.Keys.secp256K1.privateKey;
+      const issuerDID = Fixtures.DIDs.prismDIDDefault;
+
+      beforeEach(() => {
+        vi.spyOn(plutoMock, "getDIDPrivateKeysByDID").mockResolvedValue([
+          privateKey,
+        ]);
+      });
+
+      test("expired JWT - should return false", async () => {
+        const expiredTimestamp = Math.floor(Date.now() / 1000) - 60; // 60 seconds in the past
+
+        const jws = await sut.signWithDID(
+          issuerDID,
+          { exp: expiredTimestamp },
+          {},
+          privateKey,
+        );
+
+        const result = await sut.verify({ jws, issuerDID });
+
+        expect(result).toBe(false);
+      });
+
+      test("non-expired JWT - should not fail due to expiration", async () => {
+        const futureTimestamp = Math.floor(Date.now() / 1000) + 600; // 10 minutes in the future
+
+        const jws = await sut.signWithDID(
+          issuerDID,
+          { exp: futureTimestamp },
+          {},
+          privateKey,
+        );
+
+        const result = await sut.verify({ jws, issuerDID });
+
+        expect(result).toBe(true);
+      });
+    });
   });
 
   describe("round trip", () => {


### PR DESCRIPTION
Adds exp claim validation to JWT.verify. Previously, JWT.verify validated the signature and DIDs but allowed expired JWTs to return true. This fix ensures that if an exp claim is present, it is validated against the current timestamp, returning false if the JWT is expired, while preserving the existing behavior for JWTs missing the exp claim.

Fixes #489

### Description: 
Summarize the changes you're submitting in a few sentences, including Jira ticket ATL-xxxx if applicable.
Link to any discussion, related issues and bug reports to give the context to help the reviewer understand the PR.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
