### PR TITLE
fix(pollux): improve JWT VC/VP payload validation

### DIFF
--- a/packages/lib/sdk/src/pollux/models/JWTVerifiableCredential.ts
+++ b/packages/lib/sdk/src/pollux/models/JWTVerifiableCredential.ts
@@ -54,6 +54,46 @@ export class JWTCredential
   extends Credential
   implements ProvableCredential, StorableCredential, Pluto.Storable {
 
+  private static isObject(value: unknown): value is Record<string, any> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
+  private static validateW3CCredential(vc: unknown) {
+    if (!JWTCredential.isObject(vc)) {
+      throw new PolluxError.InvalidCredentialError("Invalid vc in credential payload should be an object");
+    }
+
+    if (!Array.isArray(vc["@context"]) || vc["@context"].length === 0) {
+      throw new PolluxError.InvalidCredentialError("Invalid vc in credential payload should include a non-empty @context array");
+    }
+
+    if (!Array.isArray(vc.type) || vc.type.length === 0) {
+      throw new PolluxError.InvalidCredentialError("Invalid vc in credential payload should include a non-empty type array");
+    }
+
+    if (!JWTCredential.isObject(vc.credentialSubject)) {
+      throw new PolluxError.InvalidCredentialError("Invalid vc in credential payload should include a credentialSubject object");
+    }
+  }
+
+  private static validateW3CPresentation(vp: unknown) {
+    if (!JWTCredential.isObject(vp)) {
+      throw new PolluxError.InvalidCredentialError("Invalid vp in presentation payload should be an object");
+    }
+
+    if (!Array.isArray(vp["@context"]) || vp["@context"].length === 0) {
+      throw new PolluxError.InvalidCredentialError("Invalid vp in presentation payload should include a non-empty @context array");
+    }
+
+    if (!Array.isArray(vp.type) || vp.type.length === 0) {
+      throw new PolluxError.InvalidCredentialError("Invalid vp in presentation payload should include a non-empty type array");
+    }
+
+    if (!Array.isArray(vp.verifiableCredential)) {
+      throw new PolluxError.InvalidCredentialError("Invalid vp in presentation payload should include a verifiableCredential array");
+    }
+  }
+
   public credentialType = CredentialType.JWT;
   public recoveryId = JWTVerifiableCredentialRecoveryId;
   public properties = new Map<JWT.Claims | JWT_VC_PROPS | JWT_VP_PROPS, any>();
@@ -244,10 +284,8 @@ export class JWTCredential
         throw new PolluxError.InvalidCredentialError("Invalid revoked in credential payload should be boolean");
       }
 
-      //TODO: Improve validation of VC
-      if (typeof payload[JWT_VC_PROPS.vc] !== 'undefined' &&
-        typeof payload[JWT_VC_PROPS.vc] !== 'object') {
-        throw new PolluxError.InvalidCredentialError("Invalid vc in credential payload should be an object");
+      if (payload[JWT_VC_PROPS.vc] !== undefined) {
+        JWTCredential.validateW3CCredential(payload[JWT_VC_PROPS.vc]);
       }
 
     } else {
@@ -277,10 +315,8 @@ export class JWTCredential
         throw new PolluxError.InvalidCredentialError("Invalid exp in presentation payload should be number");
       }
 
-      //TODO: Improve validation of VP
-      if (typeof payload[JWT_VP_PROPS.vp] !== 'undefined' &&
-        typeof payload[JWT_VP_PROPS.vp] !== 'object') {
-        throw new PolluxError.InvalidCredentialError("Invalid vp in presentation payload should be an object");
+      if (payload[JWT_VP_PROPS.vp] !== undefined) {
+        JWTCredential.validateW3CPresentation(payload[JWT_VP_PROPS.vp]);
       }
     }
 
@@ -435,4 +471,3 @@ export class JWTCredential
     };
   }
 }
-

--- a/packages/lib/sdk/tests/pollux/JWTCredential.test.ts
+++ b/packages/lib/sdk/tests/pollux/JWTCredential.test.ts
@@ -60,7 +60,7 @@ describe("JWTCredential", () => {
   test("should throw an error when calling verifiableCredential on a presentation", async () => {
     const jwtString = await createJWT({
       iss: Fixtures.DIDs.prismDIDDefault.toString(),
-      vp: {} as any
+      vp: { "@context": ["https://www.w3.org/2018/presentations/v1"], type: ["VerifiablePresentation"], verifiableCredential: [] } as any
     });
 
     const credential = JWTCredential.fromJWS(jwtString);
@@ -71,7 +71,7 @@ describe("JWTCredential", () => {
   test("should throw an error when calling subject on a presentation", async () => {
     const jwtString = await createJWT({
       iss: Fixtures.DIDs.prismDIDDefault.toString(),
-      vp: {} as any
+      vp: { "@context": ["https://www.w3.org/2018/presentations/v1"], type: ["VerifiablePresentation"], verifiableCredential: [] } as any
     });
 
     const credential = JWTCredential.fromJWS(jwtString);
@@ -82,7 +82,7 @@ describe("JWTCredential", () => {
   test("should throw an error when calling presentation on a presentation", async () => {
     const jwtString = await createJWT({
       iss: Fixtures.DIDs.prismDIDDefault.toString(),
-      vp: {} as any
+      vp: { "@context": ["https://www.w3.org/2018/presentations/v1"], type: ["VerifiablePresentation"], verifiableCredential: [] } as any
     });
 
     const credential = JWTCredential.fromJWS(jwtString);
@@ -156,5 +156,77 @@ describe("JWTCredential", () => {
     });
 
     expect(() => JWTCredential.fromJWS(jwtString)).throws(Domain.PolluxError.InvalidCredentialError, "Invalid vc in credential payload should be an object");
+  });
+
+  test("Should throw an error when vc is missing @context in jwt credential", async () => {
+    const jwtString = await createJWT({
+      iss: Fixtures.DIDs.prismDIDDefault.toString(),
+      vc: {
+        type: ["VerifiableCredential"],
+        credentialSubject: {}
+      } as any
+    });
+
+    expect(() => JWTCredential.fromJWS(jwtString)).throws(Domain.PolluxError.InvalidCredentialError, "Invalid vc in credential payload should include a non-empty @context array");
+  });
+
+  test("Should throw an error when vc is missing type in jwt credential", async () => {
+    const jwtString = await createJWT({
+      iss: Fixtures.DIDs.prismDIDDefault.toString(),
+      vc: {
+        "@context": ["https://www.w3.org/2018/credentials/v1"],
+        credentialSubject: {}
+      } as any
+    });
+
+    expect(() => JWTCredential.fromJWS(jwtString)).throws(Domain.PolluxError.InvalidCredentialError, "Invalid vc in credential payload should include a non-empty type array");
+  });
+
+  test("Should throw an error when vc is missing credentialSubject in jwt credential", async () => {
+    const jwtString = await createJWT({
+      iss: Fixtures.DIDs.prismDIDDefault.toString(),
+      vc: {
+        "@context": ["https://www.w3.org/2018/credentials/v1"],
+        type: ["VerifiableCredential"]
+      } as any
+    });
+
+    expect(() => JWTCredential.fromJWS(jwtString)).throws(Domain.PolluxError.InvalidCredentialError, "Invalid vc in credential payload should include a credentialSubject object");
+  });
+
+  test("Should throw an error when vp is missing @context in jwt presentation", async () => {
+    const jwtString = await createJWT({
+      iss: Fixtures.DIDs.prismDIDDefault.toString(),
+      vp: {
+        type: ["VerifiablePresentation"],
+        verifiableCredential: []
+      } as any
+    });
+
+    expect(() => JWTCredential.fromJWS(jwtString)).throws(Domain.PolluxError.InvalidCredentialError, "Invalid vp in presentation payload should include a non-empty @context array");
+  });
+
+  test("Should throw an error when vp is missing type in jwt presentation", async () => {
+    const jwtString = await createJWT({
+      iss: Fixtures.DIDs.prismDIDDefault.toString(),
+      vp: {
+        "@context": ["https://www.w3.org/2018/presentations/v1"],
+        verifiableCredential: []
+      } as any
+    });
+
+    expect(() => JWTCredential.fromJWS(jwtString)).throws(Domain.PolluxError.InvalidCredentialError, "Invalid vp in presentation payload should include a non-empty type array");
+  });
+
+  test("Should throw an error when vp is missing verifiableCredential in jwt presentation", async () => {
+    const jwtString = await createJWT({
+      iss: Fixtures.DIDs.prismDIDDefault.toString(),
+      vp: {
+        "@context": ["https://www.w3.org/2018/presentations/v1"],
+        type: ["VerifiablePresentation"]
+      } as any
+    });
+
+    expect(() => JWTCredential.fromJWS(jwtString)).throws(Domain.PolluxError.InvalidCredentialError, "Invalid vp in presentation payload should include a verifiableCredential array");
   });
 });


### PR DESCRIPTION
Improves validation for JWT VC/VP payloads in `JWTCredential`.

Added validation for required VC fields:
- `@context`
- `type`
- `credentialSubject`

Added validation for required VP fields:
- `@context`
- `type`
- `verifiableCredential`

Also added tests for invalid VC/VP payloads.