### PR TITLE
fix(pollux): replace generic Error with domain-specific PolluxError/CastorError in JWT utils

### DIFF
--- a/packages/lib/sdk/src/pollux/utils/jwt/CreateJwt.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/CreateJwt.ts
@@ -1,5 +1,6 @@
 import { ES256KSigner, type Signer, createJWT } from "did-jwt";
 import * as Domain from "@hyperledger/identus-domain";
+import { PolluxError } from "@hyperledger/identus-domain";
 import { asJsonObj, expect } from "../../../utils";
 import { Task } from "../../../utils/tasks";
 import { type AgentContext } from "../../../edge-agent/Context";
@@ -36,7 +37,7 @@ export class CreateJWT extends Task<string, Args> {
     const privateKey = expect(signingKey?.privateKey ?? this.args.privateKey, "key not found");
 
     if (!privateKey?.isSignable()) {
-      throw new Error("Key is not signable");
+      throw new PolluxError.InvalidCredentialError("Key is not signable");
     }
 
     // secp256k1 uses compact encoding while apollo returns der signatures so far

--- a/packages/lib/sdk/src/pollux/utils/jwt/CreateSDJWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/CreateSDJWT.ts
@@ -1,4 +1,5 @@
 import type * as Domain from "@hyperledger/identus-domain";
+import { PolluxError } from "@hyperledger/identus-domain";
 import { Task } from "../../../utils/tasks";
 import { SDJwtVcInstance, type SdJwtVcPayload, } from "@sd-jwt/sd-jwt-vc";
 import type { DisclosureFrame } from '@sd-jwt/types';
@@ -39,7 +40,7 @@ export class CreateSDJWT extends Task<string, Args> {
     const keyId = signingKey?.kid;
     const privateKey = expect(signingKey?.privateKey, "key not found");
     if (!privateKey?.isSignable()) {
-      throw new Error("Key is not signable");
+      throw new PolluxError.InvalidCredentialError("Key is not signable");
     }
     const config = ctx.SDJWT.getSKConfig(privateKey);
     const sdjwt = new SDJwtVcInstance(config);

--- a/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
@@ -1,5 +1,6 @@
 import { base64url } from "multiformats/bases/base64";
 import * as Domain from "@hyperledger/identus-domain";
+import { PolluxError, CastorError } from "@hyperledger/identus-domain";
 import { JWTCredential } from "../../models/JWTVerifiableCredential";
 import { Task, isNil } from "../../../utils";
 import { CreateJWT } from "./CreateJwt";
@@ -47,16 +48,16 @@ export class JWT extends Task.Runner {
       const verificationMethods = resolved.didDocument?.verificationMethod;
 
       if (!verificationMethods) {
-        throw new Error("Invalid did document");
+        throw new CastorError.NotPossibleToResolveDID("Invalid did document: no verification methods found");
       }
 
       const jwtObject = JWTCredential.fromJWS(jws);
       if (jwtObject.issuer !== issuerDID.toString()) {
-        throw new Error("Invalid issuer");
+        throw new PolluxError.InvalidCredentialError("JWT issuer does not match the expected DID");
       }
 
       if (jwtObject.isCredential && holderDID && holderDID.toString() !== jwtObject.subject) {
-        throw new Error("Invalid subject (holder)");
+        throw new PolluxError.InvalidCredentialError("JWT subject (holder) does not match the expected DID");
       }
 
       const decoded = await this.decode(jws);
@@ -66,7 +67,7 @@ export class JWT extends Task.Runner {
           const pk = await this.runTask(new PKInstance({ verificationMethod }));
 
           if (isNil(pk) || !pk.canVerify()) {
-            throw new Error("Invalid key verification method type found");
+            throw new CastorError.InvalidKeyError("Invalid key verification method type found");
           }
 
           const decodedSignature = base64url.baseDecode(decoded.signature);

--- a/packages/lib/sdk/src/pollux/utils/jwt/ResolveDID.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/ResolveDID.ts
@@ -1,5 +1,6 @@
 import type * as DIDResolver from "did-resolver";
 import * as Domain from "@hyperledger/identus-domain";
+import { CastorError } from "@hyperledger/identus-domain";
 import { Task, asArray, isEmpty } from "../../../utils";
 import { type AgentContext } from "../../../edge-agent/Context";
 
@@ -46,7 +47,7 @@ export class ResolveDID extends Task<DIDResolver.DIDResolutionResult, Args> {
         );
       }
 
-      throw new Error("Invalid KeyType");
+      throw new CastorError.InvalidKeyError("Invalid KeyType: verification method has no recognized public key encoding");
     });
 
     return {

--- a/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
@@ -5,6 +5,7 @@ import { type Disclosure } from '@sd-jwt/utils';
 import { decodeSdJwtSync, getClaimsSync } from '@sd-jwt/decode';
 import type { DisclosureFrame, PresentationFrame } from '@sd-jwt/types';
 import type * as Domain from '@hyperledger/identus-domain';
+import { PolluxError, CastorError } from '@hyperledger/identus-domain';
 import { SDJWTCredential } from '../../models/SDJWTVerifiableCredential';
 import { Task, notNil } from "../../../utils";
 import { ResolveDID } from "./ResolveDID";
@@ -21,7 +22,7 @@ export const defaultHashConfig = {
     if (safeAlg === 'SHA512') {
       return Uint8Array.from(Hashing.sha512().update(data).digest());
     }
-    throw new Error(`Invalid Hashing Algorithm. Valid options are: 'SHA256', 'SHA512'`);
+    throw new PolluxError.InvalidCredentialError(`Invalid Hashing Algorithm. Valid options are: 'SHA256', 'SHA512'`);
   }
 };
 
@@ -62,12 +63,12 @@ export class SDJWT extends Task.Runner {
     const resolved = await this.runTask(new ResolveDID({ did: issuerDID.toString() }));
     const verificationMethods = resolved.didDocument?.verificationMethod;
     if (!verificationMethods) {
-      throw new Error("Invalid did document");
+      throw new CastorError.NotPossibleToResolveDID("Invalid did document: no verification methods found");
     }
     const jwtObject = SDJWTCredential.fromJWS(jws);
 
     if (jwtObject.issuer && jwtObject.issuer !== issuerDID.toString()) {
-      throw new Error("Invalid issuer");
+      throw new PolluxError.InvalidCredentialError("SDJWT issuer does not match the expected DID");
     }
     const kidHeader = jwtObject.core.jwt?.header?.kid;
     const methods = notNil(kidHeader)
@@ -124,7 +125,7 @@ export class SDJWT extends Task.Runner {
       signAlg: publicKey.alg.toLocaleLowerCase(),
       verifier: async (data: string | Uint8Array, signatureEncoded: string) => {
         if (!publicKey.canVerify()) {
-          throw new Error("Cannot verify with this key");
+          throw new PolluxError.InvalidCredentialError("Cannot verify with this key: key does not support verification");
         }
         const signature = Buffer.from(base64url.baseDecode(signatureEncoded));
         return publicKey.verify(Buffer.from(data), signature)
@@ -139,7 +140,7 @@ export class SDJWT extends Task.Runner {
       if (crypto && typeof crypto.getRandomValues === 'function') {
         return crypto.getRandomValues(bytes);
       }
-      throw new Error('crypto.getRandomValues must be defined');
+      throw new PolluxError.InvalidCredentialError('crypto.getRandomValues must be defined');
     }
     if (length <= 0) {
       return '';
@@ -158,7 +159,7 @@ export class SDJWT extends Task.Runner {
       signAlg: privateKey.alg.toLocaleLowerCase(),
       signer: async (data: string | Uint8Array) => {
         if (!privateKey.isSignable()) {
-          throw new Error("Cannot sign with this key");
+          throw new PolluxError.InvalidCredentialError("Cannot sign with this key: key does not support signing");
         }
         const signature = privateKey.sign(Buffer.from(data));
         const signatureEncoded = base64url.baseEncode(signature);

--- a/packages/lib/sdk/tests/pollux/JWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/JWT.test.ts
@@ -95,7 +95,7 @@ describe("Domain - JWT", () => {
     test("non signable key used - throws", async () => {
       const result = sut.signWithDID(Fixtures.DIDs.prismDIDDefault, { payload: 123 }, {}, Fixtures.Keys.x25519.privateKey);
 
-      await expect(result).rejects.toThrow("Key is not signable");
+      await expect(result).rejects.toThrow(Domain.PolluxError.InvalidCredentialError);
     });
 
     describe("purpose", () => {

--- a/packages/lib/sdk/tests/pollux/SDJWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/SDJWT.test.ts
@@ -66,7 +66,7 @@ describe("Domain - SDJWT", () => {
         issuerDID: Fixtures.DIDs.peerDID1
       });
 
-      await expect(result).rejects.toThrow("Invalid did document");
+      await expect(result).rejects.toThrow(Domain.CastorError.NotPossibleToResolveDID);
     });
 
     test("issuerDID doesnt match jwt issuer - returns false", async () => {
@@ -75,7 +75,7 @@ describe("Domain - SDJWT", () => {
         issuerDID: Fixtures.DIDs.peerDID3
       });
 
-      await expect(result).rejects.toThrow("Invalid issuer");
+      await expect(result).rejects.toThrow(Domain.PolluxError.InvalidCredentialError);
     });
 
   });


### PR DESCRIPTION
Replaces 13 instances of generic `throw new Error()` with domain-specific error types across the JWT/SDJWT utility layer, enabling callers to programmatically distinguish between different error conditions.

### Error Mapping

| File | Generic Error | Domain Error |
|---|---|---|
| `SDJWT.ts` | Invalid Hashing Algorithm | `PolluxError.InvalidCredentialError` |
| `SDJWT.ts` | Invalid did document | `CastorError.NotPossibleToResolveDID` |
| `SDJWT.ts` | Invalid issuer | `PolluxError.InvalidCredentialError` |
| `SDJWT.ts` | Cannot verify/sign with this key | `PolluxError.InvalidCredentialError` |
| `SDJWT.ts` | crypto.getRandomValues must be defined | `PolluxError.InvalidCredentialError` |
| `JWT.ts` | Invalid did document | `CastorError.NotPossibleToResolveDID` |
| `JWT.ts` | Invalid issuer | `PolluxError.InvalidCredentialError` |
| `JWT.ts` | Invalid subject (holder) | `PolluxError.InvalidCredentialError` |
| `JWT.ts` | Invalid key verification method | `CastorError.InvalidKeyError` |
| `ResolveDID.ts` | Invalid KeyType | `CastorError.InvalidKeyError` |
| `CreateJwt.ts` | Key is not signable | `PolluxError.InvalidCredentialError` |
| `CreateSDJWT.ts` | Key is not signable | `PolluxError.InvalidCredentialError` |

### Rationale

- **Programmatic error handling**: Callers can catch specific error types rather than parsing error messages
- **Better debugging**: Stack traces clearly indicate the error domain (Pollux vs Castor)
- **Identity Portal readiness**: The Portal can display meaningful, category-specific error messages to users

### Checklist
- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the Allowlist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the conventional commit specification
