### PR TITLE
feat: add E2E test for wallet restore and mediator message pickup

### DIFF
--- a/integration-tests/e2e-tests/features/mediator_message_pickup.feature
+++ b/integration-tests/e2e-tests/features/mediator_message_pickup.feature
@@ -18,5 +18,5 @@ Feature: Mediator message pickup after wallet restore
       | did       | kid     | did_schema |
       | secp256k1 | assert1 | secp256k1  |
       | ed25519   | assert1 | ed25519    |
-      |
+
 

--- a/integration-tests/e2e-tests/features/mediator_message_pickup.feature
+++ b/integration-tests/e2e-tests/features/mediator_message_pickup.feature
@@ -1,0 +1,20 @@
+@mediator_pickup
+Feature: Mediator message pickup after wallet restore
+  When a wallet that was connected to a Mediator is destroyed and later recovered
+  from the same mnemonics, it should retrieve any messages that were queued
+  at the Mediator while it was disconnected
+
+  Scenario Outline: Restored wallet picks up messages queued at Mediator while disconnected
+    Given Cloud Agent is connected to Edge Agent                             
+    And Cloud Agent uses did='<did>' and kid='<kid>' for issuance           
+    And Cloud Agent uses jwt schema issued with did='<did_schema>'           
+    And Edge Agent has created a backup                                      
+    When Edge Agent is dismissed                                             
+    And Cloud Agent offers '1' jwt credentials                               
+    And a new Restored Agent is restored from Edge Agent                   
+    Then Restored Agent should receive the credentials offer from Cloud Agent
+
+    Examples:
+      | did       | kid     | did_schema |
+      | secp256k1 | assert1 | secp256k1  |
+      | ed25519   | assert1 | ed25519    |

--- a/integration-tests/e2e-tests/features/mediator_message_pickup.feature
+++ b/integration-tests/e2e-tests/features/mediator_message_pickup.feature
@@ -1,0 +1,20 @@
+@mediator_pickup
+Feature: Mediator message pickup after wallet restore
+  When a wallet that was connected to a Mediator is destroyed and later recovered
+  from the same mnemonics, it should retrieve any messages that were queued
+  at the Mediator while it was disconnected
+
+  Scenario Outline: Restored wallet picks up messages queued at Mediator while disconnected
+    Given Cloud Agent is connected to Edge Agent
+    And Cloud Agent uses did='<did>' and kid='<kid>' for issuance
+    And Cloud Agent uses jwt schema issued with did='<did_schema>'
+    And Edge Agent has created a backup
+    When Edge Agent is dismissed
+    And Cloud Agent offers '1' jwt credentials
+    And a new Restored Agent is restored from Edge Agent
+    Then Restored Agent should receive the credentials offer from Cloud Agent
+
+    Examples:
+      | did       | kid     | did_schema |
+      | secp256k1 | assert1 | secp256k1  |
+      | ed25519   | assert1 | ed25519    |

--- a/integration-tests/e2e-tests/features/mediator_message_pickup.feature
+++ b/integration-tests/e2e-tests/features/mediator_message_pickup.feature
@@ -18,3 +18,5 @@ Feature: Mediator message pickup after wallet restore
       | did       | kid     | did_schema |
       | secp256k1 | assert1 | secp256k1  |
       | ed25519   | assert1 | ed25519    |
+      |
+


### PR DESCRIPTION
## Context
This PR implements the E2E test for hyperledger-identus/integration#82.

The issue was filed in the `integration` repo, which is the orchestrator
that runs tests across all SDKs. However, the actual E2E test scenarios
live in each SDK repo — the `integration` repo clones them and executes
them against live services. This was clarified by the maintainer
(@amagyar-iohk) in the issue comments.

The correct place to implement this test is here in `sdk-ts`, following
the same BDD pattern used by all other E2E scenarios (backup.feature,
create_connection.feature, etc.).

## Summary
Adds E2E scenario for wallet restore + mediator message pickup.

When a wallet is destroyed and later recovered from the same seed,
it should retrieve messages that were queued at the Mediator while
it was offline.

## What changed
- Added `integration-tests/e2e-tests/features/mediator_message_pickup.feature`

## Implementation notes
All 8 Gherkin steps map to existing step definitions — no new step
definitions or workflow methods were needed:
- `CloudAgentSteps.ts` — connection setup, issuance config, credential offer
- `EdgeAgentSteps.ts` — backup, dismiss, restore, receive offer

The key insight is that `EdgeAgentWorkflow.backupAndRestoreToNewAgent()`
calls `sdk.start()` on the restored wallet, which reconnects to the
Mediator using the same peer DIDs from the backup — causing the Mediator
to deliver any queued messages automatically.

Covers both secp256k1 and ed25519 key curves via Scenario Outline.
