### PR TITLE
fix(pluto): expose Pluto.create() static method in type definitions

### DIFF
--- a/packages/lib/sdk/src/index.ts
+++ b/packages/lib/sdk/src/index.ts
@@ -19,6 +19,7 @@ export * from "./castor";
 export * from "./mercury";
 export * from './edge-agent'
 export * from "./pluto";
+export type { CreateOptions } from "./pluto";
 
 // Domain and utilities
 export * as Domain from "@hyperledger/identus-domain";

--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -264,7 +264,7 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
    * });
    * ```
    */
-  static async create(options: CreateOptions) {
+  static async create(options: CreateOptions): Promise<Pluto> {
     const { keyRestoration } = options;
     if ('store' in options) {
       return Pluto.#createWithStore(options.store, keyRestoration);


### PR DESCRIPTION
### Description

`Pluto.create()` is the intended way to instantiate Pluto in browser apps but it's completely missing from the published type definitions in `@hyperledger/identus-sdk@7.0.0`. So right now every TypeScript consumer has to do this just to use it:

```typescript
const PlutoCreate = SDK.Pluto as unknown as {
  create(opts: { dbName: string; keyRestoration: Apollo }): Promise<Pluto>;
};
const pluto = await PlutoCreate.create({ dbName, keyRestoration: apollo });
```

The method works fine at runtime , the types just don't expose it.

**Why this happens:** Declaration emit was silently dropping `create()` because it had no explicit return type and `CreateOptions` wasn't exported from the barrel. TypeScript can't generate declarations for methods when it can't fully resolve the types involved.

**The fix is just 2 files:**

1. `Pluto.ts` – added explicit `Promise<Pluto>` return type to `static async create(options: CreateOptions)`
2. `index.ts` – added `export type { CreateOptions } from "./pluto"`

After this, it just works:

```typescript
const pluto = await SDK.Pluto.create({
  dbName: "my-database",
  keyRestoration: apollo,
});
```

### Alternatives Considered

- **Adding `create()` to `Domain.Pluto` interface** – doesn't work, TypeScript interfaces can't have static methods. Would need a separate `PlutoConstructor` interface which feels like overkill for what's really just a missing return type.

- **`.d.ts` patch file** – would unblock consumers but hides the real problem. Better to fix it at the source so it doesn't break again later.

- **Type alias instead of re-export for `CreateOptions`** – would just duplicate the type. A direct `export type` re-export stays in sync automatically.

<img width="903" height="317" alt="Screenshot 2026-04-10 193835" src="https://github.com/user-attachments/assets/c82cc122-32d4-4f79-94eb-749898ec2fbf" />
Generated .d.ts output after fix – Pluto.create() and CreateOptions now visible

### Checklist

- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the Allowlist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the conventional commit specification