### PR TITLE
fix(pluto): restore SD+JWT credentials using SDJWTCredential

### DIFF
--- a/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Restore.ts
+++ b/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Restore.ts
@@ -4,6 +4,7 @@ import { Secp256k1PrivateKey } from "../../../../apollo/utils/Secp256k1PrivateKe
 import { X25519PrivateKey } from "../../../../apollo/utils/X25519PrivateKey";
 import { AnonCredsCredential } from "../../../../plugins/internal/anoncreds";
 import { JWTCredential } from "../../../../pollux/models/JWTVerifiableCredential";
+import { SDJWTCredential } from "../../../../pollux/models/SDJWTVerifiableCredential";
 import { notEmptyString, notNil } from "../../../../utils";
 import { type IRestoreTask } from "../interfaces";
 import { base64url } from "multiformats/bases/base64";
@@ -33,7 +34,7 @@ export class RestoreTask implements IRestoreTask {
         return JWTCredential.fromJWS(decoded);
       }
       if (item.recovery_id === "sdjwt") {
-        return JWTCredential.fromJWS(decoded);
+        return SDJWTCredential.fromJWS(decoded);
       }
       if (item.recovery_id === "anoncred") {
         return AnonCredsCredential.fromJson(decoded);


### PR DESCRIPTION
## Summary

Fixes #458 — SD+JWT credentials were incorrectly restored as `JWTCredential` during backup restore, causing selective disclosure data (disclosures) to be lost and making restored credentials unusable for presentations.

## Problem

In `Restore.ts`, the `restoreCredentials()` method handled the `"sdjwt"` recovery ID by calling `JWTCredential.fromJWS(decoded)` instead of `SDJWTCredential.fromJWS(decoded)`. This meant:

1. SD-JWT disclosures were stripped during restore
2. Restored credentials lost their `CredentialType.SDJWT` type
3. Present-proof requests after restore would fail

## Fix

- Import `SDJWTCredential` from `../../../../pollux/models/SDJWTVerifiableCredential`
- Use `SDJWTCredential.fromJWS(decoded)` for `recovery_id === "sdjwt"` 

This preserves the full SD-JWT structure including disclosures, `_sd` hashes, and `_sd_alg` during backup/restore.

## Changes

- `packages/lib/sdk/src/pluto/backup/versions/0_0_1/Restore.ts` — 2 lines changed (1 import added, 1 method call fixed)
