### PR TITLE
fix(pollux): check exp claim in JWT.verify

### DIFF
--- a/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
@@ -62,6 +62,13 @@ export class JWT extends Task.Runner {
 
       const decoded = await this.decode(jws);
 
+      // Verify expiration (exp) claim per RFC 7519 Section 4.1.4
+      // If exp is present and the current time is at or past it, the JWT is expired
+      const exp = decoded.payload.exp;
+      if (typeof exp === "number" && Math.floor(Date.now() / 1000) >= exp) {
+        return false;
+      }
+
       for (const verificationMethod of verificationMethods) {
         try {
           const pk = await this.runTask(new PKInstance({ verificationMethod }));

--- a/packages/lib/sdk/tests/pollux/JWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/JWT.test.ts
@@ -204,6 +204,61 @@ describe("Domain - JWT", () => {
 
       expect(result).toBe(false);
     });
+
+    describe("expiration", () => {
+      const privateKey = Secp256k1PrivateKey.from.String(
+        "8bfd5ff83034bbc004950de2b3a02cdafbbff9faebcb63640c895959a2d3da24",
+        "hex",
+      );
+      const issuerDID = Domain.DID.from(
+        "did:prism:9e93a84d492c62e03ab114e0b7a7b4a6880cd0e079f358d2196dc9c312dadb90:Co0CCooCElwKB21hc3RlcjAQAUJPCglzZWNwMjU2azESIBG7LMd7RA5-ckcPQICROrUbKx35x4aFAXjt_zIoWKAbGiD9WlLNP0Lr7JyQ7Q6uoY-m2TnygmAf8EBBTHGYzxm4exJkCg9hdXRoZW50aWNhdGlvbjAQBEJPCglzZWNwMjU2azESIBG7LMd7RA5-ckcPQICROrUbKx35x4aFAXjt_zIoWKAbGiD9WlLNP0Lr7JyQ7Q6uoY-m2TnygmAf8EBBTHGYzxm4exJECghpc3N1aW5nMBACSjYKB0VkMjU1MTkSKzh0dUVjUDRsZFhMQlV6US1YdEpDS1AwUC14QU5acV9SUnZQSDBIYXFWTjg",
+      );
+
+      beforeEach(() => {
+        vi.spyOn(plutoMock, "getDIDPrivateKeysByDID").mockResolvedValue([privateKey]);
+      });
+
+      test("expired JWT (exp in the past) - returns false", async () => {
+        const expiredTimestamp = Math.floor(Date.now() / 1000) - 60;
+        const jws = await sut.signWithDID(
+          issuerDID,
+          { exp: expiredTimestamp },
+          {},
+          privateKey,
+        );
+
+        const result = await sut.verify({ jws, issuerDID });
+
+        expect(result).toBe(false);
+      });
+
+      test("valid JWT (exp in the future) - returns true", async () => {
+        const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+        const jws = await sut.signWithDID(
+          issuerDID,
+          { exp: futureTimestamp },
+          {},
+          privateKey,
+        );
+
+        const result = await sut.verify({ jws, issuerDID });
+
+        expect(result).toBe(true);
+      });
+
+      test("JWT without exp claim - returns true (no expiration enforced)", async () => {
+        const jws = await sut.signWithDID(
+          issuerDID,
+          {},
+          {},
+          privateKey,
+        );
+
+        const result = await sut.verify({ jws, issuerDID });
+
+        expect(result).toBe(true);
+      });
+    });
   });
 
   describe("round trip", () => {


### PR DESCRIPTION
### Description

Fixes #489 — `JWT.verify` did not check the `exp` (expiration) claim, allowing expired JWTs to be incorrectly verified as valid. This is a security vulnerability per [RFC 7519 Section 4.1.4](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4).

### Changes

- Added `exp` validation in `JWT.verify()` after the decode step and before signature verification
- If `exp` is present and `Math.floor(Date.now() / 1000) >= exp`, `verify()` returns `false`
- JWTs without an `exp` claim keep the previous behavior (no expiration enforced), preserving backward compatibility
- Added 3 unit tests covering: expired JWT, valid JWT with future `exp`, and JWT without `exp`

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/sdk-ts/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] I have checked the PR title to follow the [conventional commit specification (https://www.conventionalcommits.org/en/v1.0.0/)
