### PR TITLE
fix: did agnostic mercury

### DIFF
--- a/packages/lib/sdk/project.json
+++ b/packages/lib/sdk/project.json
@@ -1,10 +1,10 @@
 {
   "projectType": "library",
   "implicitDependencies": [
-    "@hyperledger/identus-domain",
     "@hyperledger/identus-didcomm",
-    "@hyperledger/identus-anoncreds",
     "@hyperledger/identus-jwe",
+    "@hyperledger/identus-anoncreds",
+    "@hyperledger/identus-domain",
     "@hyperledger/identus-protos"
   ],
   "tags": [

--- a/packages/lib/sdk/src/apollo/Apollo.ts
+++ b/packages/lib/sdk/src/apollo/Apollo.ts
@@ -16,6 +16,7 @@ import {
   PrismDerivationPath,
   type KeyOptions,
   isString,
+  type Key,
 } from "@hyperledger/identus-domain";
 
 import { Ed25519PrivateKey } from "./utils/Ed25519PrivateKey";
@@ -69,14 +70,14 @@ function fromSeed(
     }
   }
 
+  const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
 
   if (curve === Curve.ED25519) {
     if (seedBuff) {
       const hdKey = ApolloSDK.derivation.EdHDKey.Companion.initFromSeed(Int8Array.from(seedBuff));
       const baseKey = new Ed25519PrivateKey(Uint8Array.from(hdKey.privateKey));
-      const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
       baseKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(Uint8Array.from(hdKey.chainCode)).toString("hex"));
-      baseKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationParam).toString("hex"));
+      baseKey.keySpecification.set(KeyProperties.derivationPath, derivationParam);
       if (derivationPath) {
         const privateKey = baseKey.derive(derivationParam);
         return privateKey;
@@ -90,13 +91,12 @@ function fromSeed(
 
   if (curve === Curve.X25519) {
     if (seedBuff) {
-      const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
       const hdKey = ApolloSDK.derivation.EdHDKey.Companion.initFromSeed(Int8Array.from(seedBuff)).derive(derivationParam);
       const edKey = Ed25519PrivateKey.from.Buffer(Buffer.from(hdKey.privateKey));
       const xKey = edKey.x25519();
 
       xKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(hdKey.chainCode).toString("hex"));
-      xKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationParam).toString("hex"));
+      xKey.keySpecification.set(KeyProperties.derivationPath, derivationParam);
       xKey.keySpecification.set(KeyProperties.index, `${derivationIndex}`);
 
       return xKey;
@@ -107,7 +107,6 @@ function fromSeed(
   }
 
   if (curve === Curve.SECP256K1) {
-    const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
     const hdKey = HDKey.InitFromSeed(
       Int8Array.from(seedBuff!),
       derivationParam.split("/").slice(1).length,
@@ -124,7 +123,7 @@ function fromSeed(
 
     const baseKey = new Secp256k1PrivateKey(Uint8Array.from(hdKey.privateKey));
     baseKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(Uint8Array.from(hdKey.chainCode)).toString("hex"));
-    baseKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationParam).toString("hex"));
+    baseKey.keySpecification.set(KeyProperties.derivationPath, derivationParam);
     baseKey.keySpecification.set(KeyProperties.index, `${derivationIndex}`);
 
     if (derivationPath) {
@@ -421,6 +420,16 @@ export class Apollo implements ApolloInterface, KeyRestoration {
     )
   }
 
+  #addKeySpecification<K extends Key>(key: K, keySpecification: Record<string, string>): K {
+    for (const [prop, value] of Object.entries(keySpecification)) {
+      if (prop === KeyProperties.rawKey.toString()) continue;
+      if (value !== undefined && value !== null) {
+        key.keySpecification.set(prop, String(value));
+      }
+    }
+    return key;
+  }
+
   restorePrivateKey(key: StorableKey): PrivateKey {
     // Old keys have StorableKey.raw with the buffer, new keys use encoded key specification
     const keySpecificationBuffer = key.data ?? Buffer.from('{}');
@@ -449,12 +458,7 @@ export class Apollo implements ApolloInterface, KeyRestoration {
       throw new ApolloError.KeyRestoratonFailed(key);
     }
 
-    for (const [prop, value] of Object.entries(keySpecification)) {
-      if (prop === KeyProperties.rawKey) continue;
-      if (value !== undefined && value !== null) {
-        privateKey.keySpecification.set(prop, String(value));
-      }
-    }
+    privateKey = this.#addKeySpecification(privateKey, keySpecification);
 
     return privateKey;
   }
@@ -486,12 +490,7 @@ export class Apollo implements ApolloInterface, KeyRestoration {
       throw new ApolloError.KeyRestoratonFailed(key);
     }
 
-    for (const [prop, value] of Object.entries(keySpecification)) {
-      if (prop === KeyProperties.rawKey) continue;
-      if (value !== undefined && value !== null) {
-        publicKey.keySpecification.set(prop, String(value));
-      }
-    }
+    publicKey = this.#addKeySpecification(publicKey, keySpecification);
 
     return publicKey;
   }

--- a/packages/lib/sdk/src/apollo/utils/Ed25519PrivateKey.ts
+++ b/packages/lib/sdk/src/apollo/utils/Ed25519PrivateKey.ts
@@ -22,13 +22,10 @@ const EdHDKey = ApolloSDK.derivation.EdHDKey;
  */
 export class Ed25519PrivateKey extends PrivateKey implements DerivableKey, ExportableKey, SignableKey, StorableKey {
   public readonly recoveryId = StorableKey.recoveryId("ed25519", "priv");
-
-
   public keySpecification: Map<string, string> = new Map();
   public raw: Uint8Array;
   public size: number;
   public type = KeyTypes.EC;
-
   public readonly to = ExportableKey.factory(this, { pemLabel: "PRIVATE KEY" });
   static from = ImportableKey.factory(Ed25519PrivateKey, { pemLabel: "PRIVATE KEY" });
 
@@ -56,12 +53,11 @@ export class Ed25519PrivateKey extends PrivateKey implements DerivableKey, Expor
     );
     const derived = hdKey.derive(derivationPathStr);
     const sk = new Ed25519PrivateKey(Uint8Array.from(derived.privateKey));
-    sk.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationPathStr).toString("hex"));
+    sk.keySpecification.set(KeyProperties.derivationPath, derivationPathStr);
     sk.keySpecification.set(KeyProperties.index, `${this.index ?? 0}`);
     if (derived.chainCode) {
       sk.keySpecification.set(KeyProperties.chainCode, Buffer.from(derived.chainCode).toString("hex"));
     }
-
     return sk;
   }
 

--- a/packages/lib/sdk/src/apollo/utils/Secp256k1PrivateKey.ts
+++ b/packages/lib/sdk/src/apollo/utils/Secp256k1PrivateKey.ts
@@ -70,7 +70,8 @@ export class Secp256k1PrivateKey
       throw new ApolloError.ApolloLibError("Key generated incorrectly: missing privateKey");
     }
     const privateKey = new Secp256k1PrivateKey(Buffer.from(derivedKey.privateKey));
-    privateKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationPathStr).toString("hex"));
+    privateKey.keySpecification = new Map(this.keySpecification);
+    privateKey.keySpecification.set(KeyProperties.derivationPath, derivationPathStr);
     privateKey.keySpecification.set(KeyProperties.index, `${this.index ?? 0}`);
     if (derivedKey.chainCode) {
       privateKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(derivedKey.chainCode).toString("hex"));

--- a/packages/lib/sdk/src/edge-agent/didFunctions/CreatePrismDID.ts
+++ b/packages/lib/sdk/src/edge-agent/didFunctions/CreatePrismDID.ts
@@ -29,7 +29,6 @@ export class CreatePrismDID extends Task<Domain.DID, Args> {
   async run(ctx: AgentContext) {
     const index = await ctx.run(new PrismKeyPathIndexTask({ index: this.args.keyPathIndex }));
     const masterKeyDerivation = PrismDerivationPath.init(index, PrismDIDKeyUsage.MASTER_KEY);
-    // TODO should this be using AUTHENTICATION_KEY
     const issuingDerivation = PrismDerivationPath.init(index, PrismDIDKeyUsage.ISSUING_KEY);
 
     const seed = new Uint8Array(await ctx.Seed());

--- a/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
@@ -22,7 +22,6 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
   async resolve(did: string): Promise<DIDComm.DIDDoc | null> {
     const { DIDDocument, CastorError, Curve, expect } = await import("@hyperledger/identus-domain");
     const doc = await this.castor.resolveDID(did);
-
     const authentications: string[] = [];
     const keyAgreements: string[] = [];
     const services: DIDComm.Service[] = [];
@@ -58,10 +57,7 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
         });
       }
 
-      if (
-        coreProperty instanceof DIDDocument.Service &&
-        coreProperty.type.includes(DIDCommMessagingKey)
-      ) {
+      if (coreProperty instanceof DIDDocument.Service) {
         services.push({
           id: coreProperty.id,
           type: DIDCommMessagingKey,

--- a/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
@@ -44,13 +44,10 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
 
 
   async find_secrets(secret_ids: string[]): Promise<string[]> {
-    const peerDids = await this.pluto.getAllPeerDIDs();
     const results = await Promise.all(
       secret_ids.map(async (secretId) => {
         const secretDID = await this.parseDIDUrl(secretId);
-        const found = peerDids.find((peerDIDSecret: any) => {
-          return secretDID.did.toString() === peerDIDSecret.did.toString();
-        });
+        const found = await this.pluto.getDIDByDIDOrAlias(secretDID.did.toString());
         return found ? secretId : null;
       })
     );
@@ -59,14 +56,10 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
 
   async get_secret(secret_id: string): Promise<DIDComm.Secret | null> {
     const { DIDDocument } = await import("@hyperledger/identus-domain");
-    const peerDids = await this.pluto.getAllPeerDIDs();
     const secretDID = await this.parseDIDUrl(secret_id);
-    const found = peerDids.find((peerDIDSecret: any) => {
-      return secretDID.did.toString() === peerDIDSecret.did.toString();
-    });
+    const found = await this.pluto.getDIDByDIDOrAlias(secretDID.did.toString());
     if (found) {
-      const did = await this.castor.resolveDID(found.did.toString());
-
+      const did = await this.castor.resolveDID(found.toString());
       const [publicKeyJWK] = did.coreProperties.reduce<import("@hyperledger/identus-domain").JWK[]>((all, property) => {
         if (property instanceof DIDDocument.VerificationMethods) {
           const matchingValue =
@@ -90,12 +83,13 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
   }
 
   private async mapToSecret(
-    peerDid: import("@hyperledger/identus-domain").PeerDID,
+    did: import("@hyperledger/identus-domain").DID,
     publicKeyJWK: import("@hyperledger/identus-domain").JWK
   ): Promise<DIDComm.Secret> {
     const { Curve, KeyTypes } = await import("@hyperledger/identus-domain");
-    const privateKeyBuffer = peerDid.privateKeys.find(
-      (key) => key.keyCurve.curve === Curve.X25519
+    const privateKeys = await this.pluto.getDIDPrivateKeysByDID(did);
+    const privateKeyBuffer = privateKeys.find(
+      (key) => key.curve.toString() === Curve.X25519.toString()
     );
     if (!privateKeyBuffer) {
       throw new Error(`Invalid PrivateKey Curve ${Curve.X25519}`);
@@ -108,8 +102,7 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
     const ecnumbasis = await computeEncnumbasis(
       privateKey.publicKey()
     );
-    const id = `${peerDid.did.toString()}#${ecnumbasis}`;
-
+    const id = `${did.toString()}#${ecnumbasis}`;
     const secret: DIDComm.Secret = {
       id,
       type: "JsonWebKey2020",

--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -510,6 +510,23 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
   }
 
 
+  public async getDIDByDIDOrAlias(didOrAlias: string): Promise<Domain.DID | null> {
+    const [did] = await this.Repositories.DIDs.getModels({
+      selector: {
+        $or: [
+          {
+            alias: didOrAlias
+          },
+          {
+            uuid: didOrAlias
+          }
+        ]
+      }
+    })
+    return did ? Domain.DID.fromString(did.uuid) : null
+  }
+
+
   /** Peer DIDs **/
 
   /**

--- a/packages/lib/sdk/tests/apollo/Apollo.createPrivateKey.test.ts
+++ b/packages/lib/sdk/tests/apollo/Apollo.createPrivateKey.test.ts
@@ -86,7 +86,7 @@ describe("Apollo", () => {
         expect(result.curve).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.curve)).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.chainCode)).to.eq("99f91ece40d2b5ff6896e96fd1e626dd17bc7f21d09538795021318009a1013c");
-        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f30272f30272f3027");
+        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/0'/0'/0'");
         expect(result.getProperty(KeyProperties.index)).to.eq("0");
       });
 
@@ -103,7 +103,7 @@ describe("Apollo", () => {
         expect(result.curve).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.curve)).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.chainCode)).to.eq("fee48c5a862316d1ea59b77258850f64de2a316796db043a4ebca1616c1c0d24");
-        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f31272f30272f3027");
+        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/1'/0'/0'");
         expect(result.getProperty(KeyProperties.index)).to.eq("0");
       });
 
@@ -122,7 +122,7 @@ describe("Apollo", () => {
         expect(result.curve).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.curve)).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.chainCode)).to.eq("6bfbb6d7bee48110dd0dd1437caa9e88dba86e4bc28585e8e8ab052c96414a48");
-        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f32272f30272f3027");
+        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/2'/0'/0'");
         expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
       });
 

--- a/packages/lib/sdk/tests/apollo/keys/Secp256k1.test.ts
+++ b/packages/lib/sdk/tests/apollo/keys/Secp256k1.test.ts
@@ -64,7 +64,7 @@ describe("Keys", () => {
           expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
 
           // expect(result.getProperty(KeyProperties.derivationPath)).to.eq(derivationPath.toString());
-          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f30272f30272f3027");
+          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/0'/0'/0'");
         });
 
         test("DerivationPath - m/1'/0'/0'", () => {
@@ -79,7 +79,7 @@ describe("Keys", () => {
           expect(result.getProperty(KeyProperties.chainCode)).to.eq("f22fdc4dd573ce17243983faa6492fc33fab35ecfa3f8ad09aa958044a2752f7");
           expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
           // expect(result.getProperty(KeyProperties.derivationPath)).to.eq(`m/1'/0'/0'`);
-          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f31272f30272f3027");
+          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/1'/0'/0'");
         });
 
         test("DerivationPath - m/2'/0'/0'", () => {
@@ -93,7 +93,7 @@ describe("Keys", () => {
           expect(result.getProperty(KeyProperties.chainCode)).to.eq("e56cd109bae854dcf3fc0b766067f9e825901bf1bcfc67dc4f5eaee74cf9c8ea");
           expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
           // expect(result.getProperty(KeyProperties.derivationPath)).to.eq(`m/1'/0'/0'`);
-          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f32272f30272f3027");
+          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/2'/0'/0'");
         });
 
         test("Secp.derive returns same as HDKey.derive", () => {

--- a/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
+++ b/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
@@ -4,7 +4,6 @@ import { Castor } from "../../../src/castor";
 import { Pluto } from "../../../src/pluto/Pluto";
 import * as Domain from "@hyperledger/identus-domain";
 import { DIDCommSecretsResolver } from "../../../src/mercury/DIDCommSecretsResolver";
-import { PeerDIDCreate } from "../../../src/castor/methods/peer/PeerDIDCreate";
 import { Curve } from "@hyperledger/identus-domain";
 import * as Fixtures from "../../fixtures";
 import * as utils from '../../../src/castor/utils';
@@ -25,7 +24,8 @@ describe("Mercury DIDComm SecretsResolver", () => {
     } as any;
 
     pluto = {
-      getAllPeerDIDs: async () => [],
+      getDIDByDIDOrAlias: async () => null,
+      getDIDPrivateKeysByDID: async () => [],
     } as any;
 
     secretsResolver = new DIDCommSecretsResolver(apollo, castor, pluto);
@@ -40,7 +40,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
       const did = Domain.DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
       const secret = did.toString();
       // TODO: update when PeerDID Types are fixed
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([{ did: secret } as any]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(Domain.DID.fromString(secret));
 
       const result = await secretsResolver.find_secrets([secret]);
 
@@ -48,21 +48,32 @@ describe("Mercury DIDComm SecretsResolver", () => {
       expect(result).to.contain(secret);
     });
 
-    it("should return matched secret - no duplicates", async () => {
+    it("should return matched secret also if missing duplicates exist", async () => {
       const did = Domain.DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
       const secret = did.toString();
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([{ did: secret }, { did: secret }] as any);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(Domain.DID.fromString(secret));
+
+      const result = await secretsResolver.find_secrets([secret, secret]);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result).to.eql([secret, secret]);
+    });
+
+    it("should return matched secret for PRISM DID", async () => {
+      const did = Domain.DID.fromString("did:prism:4a5b2cb64f8faa318545eac4869c4f7b600f681a938cde99320aeeb6af1bd770");
+      const secret = did.toString();
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(Domain.DID.fromString(secret));
 
       const result = await secretsResolver.find_secrets([secret]);
 
       expect(result).to.have.lengthOf(1);
-      expect(result).to.eql([secret]);
+      expect(result).to.contain(secret);
     });
 
     it("should return empty array with unmatched secret", async () => {
       const did = Domain.DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
       const secret = did.toString();
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(null);
 
       const result = await secretsResolver.find_secrets([secret]);
 
@@ -82,20 +93,15 @@ describe("Mercury DIDComm SecretsResolver", () => {
       };
       const ecnum = "ecnum123";
       const privateKey = Fixtures.Keys.x25519.privateKey;
-      const peerDid = {
-        did: secret,
-        curve: Curve.X25519,
-        privateKeys: [
-          {
-            keyCurve: {
-              curve: privateKey.curve
-            },
-            value: privateKey.getEncoded(),
-          },
-        ],
-      } as any;
+      const privateKeys = [
+        {
+          curve: Curve.X25519,
+          value: privateKey.getEncoded(),
+        },
+      ];
 
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([peerDid]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did as any);
+      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys as any);
       vi.spyOn(castor, "resolveDID").mockResolvedValue(
         new Domain.DIDDocument(did, [
           new Domain.DIDDocument.VerificationMethods([
@@ -119,9 +125,61 @@ describe("Mercury DIDComm SecretsResolver", () => {
         id: `${secret}#${ecnum}`,
         type: "JsonWebKey2020",
         privateKeyJwk: {
-          crv: peerDid.curve,
+          crv: Curve.X25519,
           kty: "OKP",
-          d: peerDid.privateKeys[0].value.toString(),
+          d: privateKeys[0].value.toString(),
+          x: publicKeyJwk.x as any,
+        },
+      });
+    });
+
+    it("should return matched secret for PRISM DID", async () => {
+      const did = Domain.DID.fromString("did:prism:4a5b2cb64f8faa318545eac4869c4f7b600f681a938cde99320aeeb6af1bd770");
+      const secret = did.toString();
+      const publicKeyJwk: Domain.JWK.OKP = {
+        crv: Domain.Curve.X25519,
+        kid: "kid",
+        kty: "OKP",
+        x: Buffer.from(new Uint8Array()).toString("base64url"),
+      };
+      const ecnum = "ecnum123";
+      const privateKey = Fixtures.Keys.x25519.privateKey;
+
+      const privateKeys = [
+        {
+          curve: Curve.X25519,
+          value: privateKey.getEncoded(),
+        },
+      ];
+
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did as any);
+      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys as any);
+      vi.spyOn(castor, "resolveDID").mockResolvedValue(
+        new Domain.DIDDocument(did, [
+          new Domain.DIDDocument.VerificationMethods([
+            new Domain.DIDDocument.VerificationMethod(
+              secret,
+              "controller",
+              "JsonWebKey2020",
+              publicKeyJwk
+            ),
+          ]),
+        ])
+      );
+
+      vi.spyOn(utils, "computeEncnumbasis").mockReturnValue(Promise.resolve(ecnum));
+      vi.spyOn(apollo, "createPrivateKey").mockReturnValue(privateKey);
+
+      const result = await secretsResolver.get_secret(secret);
+
+      expect(result).not.to.be.null;
+      expect(result).to.eql({
+        id: `${secret}#${ecnum}`,
+        type: "JsonWebKey2020",
+        privateKeyJwk: {
+          crv: Curve.X25519,
+          kty: "OKP",
+          d: privateKeys[0].value.toString(),
           x: publicKeyJwk.x as any,
         },
       });
@@ -132,7 +190,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
         "did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ"
       );
       const secret = did.toString();
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(null);
 
       const result = await secretsResolver.get_secret(secret);
 

--- a/packages/shared/domain/src/buildingBlocks/Pluto.ts
+++ b/packages/shared/domain/src/buildingBlocks/Pluto.ts
@@ -104,6 +104,8 @@ export interface Pluto extends Startable.IController {
    */
   storeCredential(credential: Credential): Promise<void>;
 
+  getDIDByDIDOrAlias(didOrAlias: string): Promise<DID | null>;
+
   /**
    * Retrieve all stored PRISM DIDs.
    */


### PR DESCRIPTION
### Description
We are making DIDComm messaging agnostic on the did method that wants to be used

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
