### PR TITLE
fix: specific npm version on CI pipeline to avoid error on latest V11…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org/"
 
       - name: Enable Corepack
         run: corepack enable
-
-      # Ensure npm version >= 11.5.1 (lowest supporting trusted publishing)
-      - name: Upgrade npm
-        run: npm install -g npm@^11.5.1
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION


### Description
fixes https://github.com/hyperledger-identus/sdk-ts/actions/runs/24448450191/job/71431012643

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
