### PR TITLE
fix: improve didmethod abstraction

### DIFF
--- a/docs/develop/sdk/migration/migrating_7x_to_8x.md
+++ b/docs/develop/sdk/migration/migrating_7x_to_8x.md
@@ -105,25 +105,45 @@ const castor = new Castor(apollo, [
 
    -2 Adding a custom did method
 
-   By using module augmentation we can implement a did agnostic type-safe wrapper for current did methods (prism, peer) and future ones.
+   Implement the `DIDMethod` interface and pass an instance through the new
+   top-level `didMethods` parameter on `Agent.initialize` (or the `Castor`
+   constructor). TypeScript infers payloads and metadata directly from your
+   class.
 
    ```typescript
+   import type * as Domain from "@hyperledger/identus-domain";
+   import { type DIDMethod } from "@hyperledger/identus-sdk";
+
    export type CreatePayload = {
-     services?: DIDDocument.Service[];
-     keys: DIDKeys; // You customize the type with your own payloads
+     services?: Domain.DIDDocument.Service[];
+     keys: { SIGNING_KEY: Domain.PrivateKey };
    };
+
+   export class MyDIDMethod implements DIDMethod<never, CreatePayload> {
+     method = "mymethod" as const;
+     resolver = new MyResolver();
+
+     async create(opts: CreatePayload): Promise<Domain.DID> {
+       // ...
+     }
+
+     async verifySignature(did, challenge, signature) {
+       // ...
+     }
+   }
    ```
 
-   Module augmentation
+   Register with the Agent:
 
    ```typescript
-   declare module "@hyperledger/identus-sdk" {
-    interface DIDMethodTypeMap {
-      peer: {
-        createPayload: CreatePayload;
-      };
-    }
-  }
+   const agent = Agent.initialize({
+     pluto,
+     didMethods: [new MyDIDMethod()],
+   });
+
+   await agent.createDID("mymethod", {
+     keys: { SIGNING_KEY: sk },
+   }); // fully typed
    ```
 
 - Agent.initialize now accepts an async function that returns a seed (UInt8Array) vs previous hexString, if no seed function is provided, will start with random seed

--- a/docs/develop/sdk/tutorials/CustomDIDMethod.md
+++ b/docs/develop/sdk/tutorials/CustomDIDMethod.md
@@ -4,19 +4,20 @@ The SDK uses a pluggable DID method architecture. You can register your own DID 
 
 ## Overview
 
-A custom DID method consists of three pieces:
+A custom DID method consists of two pieces:
 
-1. **Type augmentation** -- declare your method's payload types in `DIDMethodTypeMap`
-2. **Method class** -- implement the `DIDMethod` interface
-3. **Registration** -- pass your method to the `Castor` constructor or `Agent` options
+1. **Method class** -- implement the `DIDMethod` interface
+2. **Registration** -- pass an instance to the `Castor` constructor or to `Agent.initialize`'s `didMethods` option
 
-## Step 1: Define Payload Types and Augment the Type Map
+No global type registration is required. TypeScript infers every payload and metadata type directly from your `DIDMethod` class, so `createDID`, `publishDID`, etc. are fully typed as soon as you pass your instance in.
 
-Create a module that declares your method's payloads and augments `DIDMethodTypeMap`. This gives `createDID`, `publishDID`, etc. full type safety for your method.
+## Step 1: Define Payload Types
+
+Declare the types your method accepts and returns. These are plain TypeScript types and do **not** need to be registered anywhere global.
 
 ```typescript
 // my-did-method/types.ts
-import { Domain } from "@hyperledger/identus-sdk";
+import type * as Domain from "@hyperledger/identus-domain";
 
 export type MyCreatePayload = {
   keys: { SIGNING_KEY: Domain.PrivateKey };
@@ -24,25 +25,12 @@ export type MyCreatePayload = {
 };
 
 export type MyPublishPayload = {
-  key: DomainPrivateKey;
+  key: Domain.PrivateKey;
   did: Domain.DID;
 };
 
 export type MyMetadata = { txHash: string };
-
-// Augment the global type map
-declare module "@hyperledger/identus-sdk" {
-  interface DIDMethodTypeMap {
-    mymethod: {
-      createPayload: MyCreatePayload;
-      publishPayload: MyPublishPayload;
-      metadata: MyMetadata;
-    };
-  }
-}
 ```
-
-**How it works:** `DIDMethodTypeMap` is an empty interface in `@hyperledger/identus-sdk`. Each DID method adds entries to it using TypeScript's [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html). The SDK's `DIDMethods`, `InferCreatePayload<M>`, etc. are mapped types that read from this map, so TypeScript automatically knows the correct payload and return types when you call `castor.createDID('mymethod', ...)`.
 
 ## Step 2: Implement the DIDMethod Interface
 
@@ -71,7 +59,7 @@ export class MyDIDMethod
     const publicKey = opts.keys.SIGNING_KEY.publicKey();
     // Build and return a DID from the public key material
     const methodId = computeMethodId(publicKey);
-    return new DID("did", "mymethod", methodId);
+    return new Domain.DID("did", "mymethod", methodId);
   }
 
   async publish(
@@ -86,13 +74,17 @@ export class MyDIDMethod
     challenge: Uint8Array,
     signature: Uint8Array
   ): Promise<boolean> {
-    // Resolve the DID and verify the signature
     const doc = await this.resolver.resolve(did.toString());
     // ... verification logic
     return true;
   }
 }
 ```
+
+The two details that make type inference work:
+
+- `method = "mymethod" as const` -- the `as const` gives the `method` field a literal string type, which the SDK uses as the dispatch key in `agent.createDID("mymethod", ...)`.
+- A concretely typed `create(opts: MyCreatePayload)` (and, if present, `publish` / `update` / `deactivate`) -- payload types are inferred from these signatures.
 
 ### Optional Operations
 
@@ -116,7 +108,7 @@ class PeerDIDMethod implements Domain.DIDMethod<never, CreatePayload> { ... }
 import { Castor } from "@hyperledger/identus-sdk";
 import { MyDIDMethod } from "./my-did-method";
 
-const castor = new Castor(apollo, [new MyDIDMethod()]);
+const castor = new Castor(apollo, [new MyDIDMethod()] as const);
 
 // Now fully typed:
 const did = await castor.createDID("mymethod", {
@@ -124,7 +116,9 @@ const did = await castor.createDID("mymethod", {
 });
 ```
 
-### Via Agent options
+### Via Agent
+
+Prefer the top-level `didMethods` param on `Agent.initialize` -- it participates in type inference so `agent.createDID` knows about your method:
 
 ```typescript
 import { Agent } from "@hyperledger/identus-sdk";
@@ -134,26 +128,33 @@ const agent = Agent.initialize({
   pluto,
   didMethods: [new MyDIDMethod()],
 });
+
+await agent.createDID("mymethod", {
+  keys: { SIGNING_KEY: myPrivateKey },
+});
 ```
 
-Custom methods passed via `didMethods` override built-in methods with the same `method` name.
+Custom methods passed via `didMethods` override built-in methods with the same `method` name (both at runtime and in the inferred types).
 
 ## Full Type Safety
 
-After augmenting `DIDMethodTypeMap`, all calls through `Castor` or `Agent` are fully type-checked:
+All calls through `Castor` or `Agent` are fully type-checked against the methods you actually registered:
 
 ```typescript
 // TypeScript knows `opts` must be MyCreatePayload
-await castor.createDID("mymethod", {
+await agent.createDID("mymethod", {
   keys: { SIGNING_KEY: sk },
 });
 
 // TypeScript error: property 'MASTER_KEY' is missing
-await castor.createDID("prism", {
+await agent.createDID("prism", {
   keys: { SIGNING_KEY: sk }, // Error!
 });
 
+// TypeScript error: method "bogus" is not registered
+await agent.createDID("bogus", {}); // Error!
+
 // TypeScript knows the return is MyMetadata
-const meta = await castor.publishDID("mymethod", { key: sk, did });
-console.log(meta); // Uint8Array with the blockchain operation, or for other sources
+const meta = await agent.publishDID("mymethod", { key: sk, did });
+console.log(meta.txHash);
 ```

--- a/packages/lib/sdk/src/castor/index.ts
+++ b/packages/lib/sdk/src/castor/index.ts
@@ -55,12 +55,12 @@ export class Castor<
     return Object.values(this.#methods).map((m) => m.resolver);
   }
 
-  #getDIDMethod<M extends RegisteredName<Extras>>(method: M): MethodMap<Extras>[M] {
+  #getDIDMethod(method: string): DIDMethodInput {
     const m = this.#methods[method];
     if (!m) {
-      throw new Error(`DID method '${String(method)}' is not registered`);
+      throw new Error(`DID method '${method}' is not registered`);
     }
-    return m as unknown as MethodMap<Extras>[M];
+    return m;
   }
 
   /**
@@ -79,30 +79,25 @@ export class Castor<
   createDID<M extends RegisteredName<Extras>>(
     method: M,
     opts: CreatePayloadOf<MethodMap<Extras>[M]>,
-  ) {
-    const didMethod = this.#getDIDMethod(method);
-    return (didMethod as { create: (o: CreatePayloadOf<MethodMap<Extras>[M]>) => Promise<Domain.DID> }).create(opts);
+  ): Promise<Domain.DID> {
+    return this.#getDIDMethod(method).create(opts);
   }
 
-  async verifySignature(
+  verifySignature(
     did: Domain.DID,
     challenge: Uint8Array,
     signature: Uint8Array
   ): Promise<boolean> {
-    const didMethod = this.#getDIDMethod(did.method as RegisteredName<Extras>);
-    return (didMethod as { verifySignature: (d: Domain.DID, c: Uint8Array, s: Uint8Array) => Promise<boolean> })
-      .verifySignature(did, challenge, signature);
+    return this.#getDIDMethod(did.method).verifySignature(did, challenge, signature);
   }
 
   publishDID<M extends RegisteredName<Extras>>(
     method: M,
     opts: PublishPayloadOf<MethodMap<Extras>[M]>,
   ): Promise<MetadataOf<MethodMap<Extras>[M]>> {
-    const didMethod = this.#getDIDMethod(method) as {
-      publish?: (o: PublishPayloadOf<MethodMap<Extras>[M]>) => Promise<MetadataOf<MethodMap<Extras>[M]>>;
-    };
+    const didMethod = this.#getDIDMethod(method);
     if (!didMethod.publish) {
-      throw new Error(`DID method '${String(method)}' does not support publish operation`);
+      throw new Error(`DID method '${method}' does not support publish operation`);
     }
     return didMethod.publish(opts);
   }
@@ -111,11 +106,9 @@ export class Castor<
     method: M,
     opts: UpdatePayloadOf<MethodMap<Extras>[M]>,
   ): Promise<MetadataOf<MethodMap<Extras>[M]>> {
-    const didMethod = this.#getDIDMethod(method) as {
-      update?: (o: UpdatePayloadOf<MethodMap<Extras>[M]>) => Promise<MetadataOf<MethodMap<Extras>[M]>>;
-    };
+    const didMethod = this.#getDIDMethod(method);
     if (!didMethod.update) {
-      throw new Error(`DID method '${String(method)}' does not support update operation`);
+      throw new Error(`DID method '${method}' does not support update operation`);
     }
     return didMethod.update(opts);
   }
@@ -124,11 +117,9 @@ export class Castor<
     method: M,
     opts: DeactivatePayloadOf<MethodMap<Extras>[M]>,
   ): Promise<MetadataOf<MethodMap<Extras>[M]>> {
-    const didMethod = this.#getDIDMethod(method) as {
-      deactivate?: (o: DeactivatePayloadOf<MethodMap<Extras>[M]>) => Promise<MetadataOf<MethodMap<Extras>[M]>>;
-    };
+    const didMethod = this.#getDIDMethod(method);
     if (!didMethod.deactivate) {
-      throw new Error(`DID method '${String(method)}' does not support deactivate operation`);
+      throw new Error(`DID method '${method}' does not support deactivate operation`);
     }
     return didMethod.deactivate(opts);
   }

--- a/packages/lib/sdk/src/castor/index.ts
+++ b/packages/lib/sdk/src/castor/index.ts
@@ -2,14 +2,14 @@ import * as Domain from '@hyperledger/identus-domain';
 import { type DIDDocument } from "@hyperledger/identus-domain";
 
 import {
-  type DIDMethod,
-  type DIDMethods,
-  type DIDMethodTypeMap,
-  type InferCreatePayload,
-  type InferPublishPayload,
-  type InferUpdatePayload,
-  type InferDeactivatePayload,
+  type CreatePayloadOf,
+  type PublishPayloadOf,
+  type UpdatePayloadOf,
+  type DeactivatePayloadOf,
+  type MetadataOf,
+  type MethodMapOf,
 } from "./methods/types";
+import { type PrismDIDMethod, type PeerDIDMethod } from "./methods";
 
 import { type DIDMethodInput } from "./types";
 import { parseParams } from "./utils";
@@ -17,28 +17,51 @@ import { parseParams } from "./utils";
 export type * from "./methods";
 
 /**
+ * All DID methods available on a Castor instance -- the built-in
+ * `PrismDIDMethod` / `PeerDIDMethod` followed by any user-supplied extras.
+ * When extras share a `method` name with a built-in, the extra wins.
+ */
+type AllMethods<Extras extends readonly DIDMethodInput[]> =
+  readonly [PrismDIDMethod, PeerDIDMethod, ...Extras];
+
+/** Map from registered DID method name to the registered instance type. */
+type MethodMap<Extras extends readonly DIDMethodInput[]> =
+  MethodMapOf<AllMethods<Extras>>;
+
+/** Registered DID method names for a Castor instance. */
+type RegisteredName<Extras extends readonly DIDMethodInput[]> =
+  keyof MethodMap<Extras> & string;
+
+/**
  * Castor is a powerful and flexible library for working with DIDs. Whether you are building a decentralised application
  * or a more traditional system requiring secure and private identity management, Castor provides the tools and features
  * you need to easily create, manage, and resolve DIDs.
  *
+ * The optional tuple type parameter `Extras` carries the concrete types of
+ * any extra DID methods passed to the constructor, so that `createDID`,
+ * `publishDID`, `updateDID` and `deactivateDID` only accept method names
+ * that are actually registered (defaults `"prism" | "peer"` plus any extras)
+ * and infer their payload types directly from each DID method instance.
+ *
  * @class Castor
  * @typedef {Castor}
  */
-export class Castor implements Domain.Castor {
-  #methods: Partial<DIDMethods> = {};
+export class Castor<
+  Extras extends readonly DIDMethodInput[] = readonly []
+> implements Domain.Castor {
+  #methods: Record<string, DIDMethodInput>;
 
   get #resolvers(): Domain.DIDResolver[] {
-    return Object.values(this.#methods).map((m) => (m as DIDMethod).resolver);
+    return Object.values(this.#methods).map((m) => m.resolver);
   }
 
-  #getDIDMethod<M extends keyof DIDMethodTypeMap>(method: M): DIDMethods[M] {
+  #getDIDMethod<M extends RegisteredName<Extras>>(method: M): MethodMap<Extras>[M] {
     const m = this.#methods[method];
     if (!m) {
       throw new Error(`DID method '${String(method)}' is not registered`);
     }
-    return m;
+    return m as unknown as MethodMap<Extras>[M];
   }
-
 
   /**
    * Creates an instance of Castor as soon as a valid cryptographic interface is provided (Apollo).
@@ -46,18 +69,19 @@ export class Castor implements Domain.Castor {
    * Pass additional DIDMethod instances to extend or override defaults.
    *
    * @param {Apollo} apollo
-   * @param {DIDMethod[]} extraMethods
+   * @param {Extras} extraMethods - tuple of custom DID methods to register
    */
-  constructor(apollo: Domain.Apollo, extraMethods: DIDMethodInput[] = []) {
-    const { didMethods } = parseParams(apollo, extraMethods);
+  constructor(apollo: Domain.Apollo, extraMethods?: Extras) {
+    const { didMethods } = parseParams(apollo, extraMethods ?? []);
     this.#methods = didMethods;
   }
 
-  createDID<M extends keyof DIDMethodTypeMap>(
+  createDID<M extends RegisteredName<Extras>>(
     method: M,
-    opts: InferCreatePayload<M>,
+    opts: CreatePayloadOf<MethodMap<Extras>[M]>,
   ) {
-    return this.#getDIDMethod(method).create(opts);
+    const didMethod = this.#getDIDMethod(method);
+    return (didMethod as { create: (o: CreatePayloadOf<MethodMap<Extras>[M]>) => Promise<Domain.DID> }).create(opts);
   }
 
   async verifySignature(
@@ -65,38 +89,44 @@ export class Castor implements Domain.Castor {
     challenge: Uint8Array,
     signature: Uint8Array
   ): Promise<boolean> {
-    const method = did.method as keyof DIDMethodTypeMap;
-    const didMethod = this.#getDIDMethod(method) as DIDMethod;
-    return didMethod.verifySignature(did, challenge, signature);
+    const didMethod = this.#getDIDMethod(did.method as RegisteredName<Extras>);
+    return (didMethod as { verifySignature: (d: Domain.DID, c: Uint8Array, s: Uint8Array) => Promise<boolean> })
+      .verifySignature(did, challenge, signature);
   }
 
-  publishDID<M extends keyof DIDMethodTypeMap>(
+  publishDID<M extends RegisteredName<Extras>>(
     method: M,
-    opts: InferPublishPayload<M>,
-  ) {
-    const didMethod = this.#getDIDMethod(method);
+    opts: PublishPayloadOf<MethodMap<Extras>[M]>,
+  ): Promise<MetadataOf<MethodMap<Extras>[M]>> {
+    const didMethod = this.#getDIDMethod(method) as {
+      publish?: (o: PublishPayloadOf<MethodMap<Extras>[M]>) => Promise<MetadataOf<MethodMap<Extras>[M]>>;
+    };
     if (!didMethod.publish) {
       throw new Error(`DID method '${String(method)}' does not support publish operation`);
     }
     return didMethod.publish(opts);
   }
 
-  updateDID<M extends keyof DIDMethodTypeMap>(
+  updateDID<M extends RegisteredName<Extras>>(
     method: M,
-    opts: InferUpdatePayload<M>,
-  ) {
-    const didMethod = this.#getDIDMethod(method);
+    opts: UpdatePayloadOf<MethodMap<Extras>[M]>,
+  ): Promise<MetadataOf<MethodMap<Extras>[M]>> {
+    const didMethod = this.#getDIDMethod(method) as {
+      update?: (o: UpdatePayloadOf<MethodMap<Extras>[M]>) => Promise<MetadataOf<MethodMap<Extras>[M]>>;
+    };
     if (!didMethod.update) {
       throw new Error(`DID method '${String(method)}' does not support update operation`);
     }
     return didMethod.update(opts);
   }
 
-  deactivateDID<M extends keyof DIDMethodTypeMap>(
+  deactivateDID<M extends RegisteredName<Extras>>(
     method: M,
-    opts: InferDeactivatePayload<M>,
-  ) {
-    const didMethod = this.#getDIDMethod(method);
+    opts: DeactivatePayloadOf<MethodMap<Extras>[M]>,
+  ): Promise<MetadataOf<MethodMap<Extras>[M]>> {
+    const didMethod = this.#getDIDMethod(method) as {
+      deactivate?: (o: DeactivatePayloadOf<MethodMap<Extras>[M]>) => Promise<MetadataOf<MethodMap<Extras>[M]>>;
+    };
     if (!didMethod.deactivate) {
       throw new Error(`DID method '${String(method)}' does not support deactivate operation`);
     }
@@ -131,9 +161,4 @@ export class Castor implements Domain.Castor {
     }
     throw new Error(`Non of the available Castor resolvers could resolve the DID '${didstr.toString()}'`);
   }
-
-
-
-
-
 }

--- a/packages/lib/sdk/src/castor/methods/index.ts
+++ b/packages/lib/sdk/src/castor/methods/index.ts
@@ -1,11 +1,13 @@
-import type { DIDMethodTypeMap } from "./types";
-
-import "./prism";
-import "./peer";
+import { PrismDIDMethod } from "./prism";
+import { PeerDIDMethod } from "./peer";
 
 export { PrismDIDMethod } from "./prism";
 export { PeerDIDMethod } from "./peer";
 
-export type RegisteredMethodName = keyof DIDMethodTypeMap;
+/**
+ * Tuple of DID methods Castor always registers by default.
+ * User-supplied extras are appended to this tuple.
+ */
+export type DefaultDIDMethods = readonly [PrismDIDMethod, PeerDIDMethod];
 
 export type * from "./types";

--- a/packages/lib/sdk/src/castor/methods/index.ts
+++ b/packages/lib/sdk/src/castor/methods/index.ts
@@ -1,5 +1,5 @@
-import { PrismDIDMethod } from "./prism";
-import { PeerDIDMethod } from "./peer";
+import { type PrismDIDMethod } from "./prism";
+import { type PeerDIDMethod } from "./peer";
 
 export { PrismDIDMethod } from "./prism";
 export { PeerDIDMethod } from "./peer";

--- a/packages/lib/sdk/src/castor/methods/peer/index.ts
+++ b/packages/lib/sdk/src/castor/methods/peer/index.ts
@@ -20,14 +20,6 @@ export type CreatePayload = {
   keys: DIDKeys;
 };
 
-declare module "../types" {
-  interface DIDMethodTypeMap {
-    peer: {
-      createPayload: CreatePayload;
-    };
-  }
-}
-
 /**
  * DID method implementation for `did:peer` (algorithm 2).
  *

--- a/packages/lib/sdk/src/castor/methods/prism/index.ts
+++ b/packages/lib/sdk/src/castor/methods/prism/index.ts
@@ -53,16 +53,6 @@ export type PublishPayload = {
 /** Serialised Atala object bytes returned after a publish operation. */
 export type Metadata = Uint8Array
 
-declare module "../types" {
-  interface DIDMethodTypeMap {
-    prism: {
-      createPayload: CreatePayload;
-      publishPayload: PublishPayload;
-      metadata: Metadata;
-    };
-  }
-}
-
 /**
  * DID method implementation for `did:prism`.
  *

--- a/packages/lib/sdk/src/castor/methods/types.ts
+++ b/packages/lib/sdk/src/castor/methods/types.ts
@@ -7,50 +7,6 @@ import { type DIDResolver, type DID, type PrivateKey, type RequiredPrismDIDKeys 
  */
 export type DIDMethodOperation<TMetadata = unknown, TRes = TMetadata> = TRes
 
-type MapGet<T, K extends string> = K extends keyof T ? T[K] : never;
-
-/**
- * Augmentable type map that registers DID methods at the type level.
- *
- * Built-in methods (`prism`, `peer`) are defined directly here so their
- * entries survive `.d.ts` bundling (rollup-plugin-dts drops `declare
- * module` blocks).  External consumers extend this interface via module
- * augmentation targeting `"@hyperledger/identus-sdk"`.
- *
- * @example
- * ```ts
- * declare module "@hyperledger/identus-sdk" {
- *   interface DIDMethodTypeMap {
- *     mymethod: {
- *       createPayload: { keys: MyKeys };
- *       metadata: MyMeta;
- *     };
- *   }
- * }
- * ```
- */
-export interface DIDMethodTypeMap { }
-
-/** Extracts the `createPayload` type for DID method `M`. */
-export type InferCreatePayload<M extends keyof DIDMethodTypeMap> =
-  MapGet<DIDMethodTypeMap[M], "createPayload">;
-
-/** Extracts the `publishPayload` type for DID method `M`. */
-export type InferPublishPayload<M extends keyof DIDMethodTypeMap> =
-  MapGet<DIDMethodTypeMap[M], "publishPayload">;
-
-/** Extracts the `updatePayload` type for DID method `M`. */
-export type InferUpdatePayload<M extends keyof DIDMethodTypeMap> =
-  MapGet<DIDMethodTypeMap[M], "updatePayload">;
-
-/** Extracts the `deactivatePayload` type for DID method `M`. */
-export type InferDeactivatePayload<M extends keyof DIDMethodTypeMap> =
-  MapGet<DIDMethodTypeMap[M], "deactivatePayload">;
-
-/** Extracts the `metadata` type for DID method `M`. */
-export type InferMetadata<M extends keyof DIDMethodTypeMap> =
-  MapGet<DIDMethodTypeMap[M], "metadata">;
-
 type OptionalMethod<Name extends string, T, Y> =
   [T] extends [never] ? { [K in Name]?: undefined } : { [K in Name]: (opts: T) => Promise<Y> };
 
@@ -112,18 +68,60 @@ export type DIDMethod<
   & OptionalMethod<'deactivate', DeactivatePayload, DIDMethodOperation<TMetadata>>;
 
 /**
- * Mapped type that derives a concrete `DIDMethod` for every entry in
- * {@link DIDMethodTypeMap}.
- *
- * SDK consumers should not need to reference this directly -- it is used
- * internally by {@link Castor} to look up method implementations.
+ * Extract the literal `method` name from a DID method instance type.
+ * Falls back to `string` when the method field is not a string literal.
  */
-export type DIDMethods = {
-  [K in keyof DIDMethodTypeMap]: DIDMethod<
-    MapGet<DIDMethodTypeMap[K], "metadata">,
-    MapGet<DIDMethodTypeMap[K], "createPayload">,
-    MapGet<DIDMethodTypeMap[K], "publishPayload">,
-    MapGet<DIDMethodTypeMap[K], "updatePayload">,
-    MapGet<DIDMethodTypeMap[K], "deactivatePayload">
-  >;
-};
+export type MethodNameOf<T> = T extends { method: infer N }
+  ? N extends string ? N : never
+  : never;
+
+/**
+ * Extract the `create` payload type from a DID method instance type.
+ */
+export type CreatePayloadOf<T> = T extends { create: (opts: infer O) => unknown } ? O : never;
+
+/**
+ * Extract the `publish` payload type from a DID method instance type.
+ * Resolves to `never` when the method does not support publishing.
+ */
+export type PublishPayloadOf<T> = T extends { publish: (opts: infer O) => unknown } ? O : never;
+
+/**
+ * Extract the `update` payload type from a DID method instance type.
+ * Resolves to `never` when the method does not support updating.
+ */
+export type UpdatePayloadOf<T> = T extends { update: (opts: infer O) => unknown } ? O : never;
+
+/**
+ * Extract the `deactivate` payload type from a DID method instance type.
+ * Resolves to `never` when the method does not support deactivating.
+ */
+export type DeactivatePayloadOf<T> = T extends { deactivate: (opts: infer O) => unknown } ? O : never;
+
+/**
+ * Extract the metadata type returned by the lifecycle operations of a
+ * DID method instance type. Uses `publish` as the canonical source.
+ */
+export type MetadataOf<T> =
+  T extends { publish: (arg: never) => Promise<infer M> } ? M :
+  T extends { update: (arg: never) => Promise<infer M> } ? M :
+  T extends { deactivate: (arg: never) => Promise<infer M> } ? M :
+  never;
+
+/**
+ * Build a `{ methodName: MethodInstance }` map from a tuple of DID method
+ * instances. When multiple entries share the same `method` name, later
+ * entries override earlier ones (so user-supplied extras can replace the
+ * built-in `prism` / `peer` implementations at the type level).
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type MethodMapOf<Methods extends readonly unknown[]> =
+  Methods extends readonly [infer Head, ...infer Tail]
+    ? Tail extends readonly unknown[]
+      ? MethodNameOf<Head> extends infer N
+        ? N extends string
+          ? Omit<{ [K in N]: Head }, keyof MethodMapOf<Tail>> & MethodMapOf<Tail>
+          : MethodMapOf<Tail>
+        : MethodMapOf<Tail>
+      : never
+    : {};

--- a/packages/lib/sdk/src/castor/types/index.ts
+++ b/packages/lib/sdk/src/castor/types/index.ts
@@ -7,15 +7,31 @@ export type PeerDIDKeys = {
 
 
 /**
- * Minimal shape that any DID method instance must satisfy in order to
+ * Structural shape that any DID method instance must satisfy in order to
  * be registered with the {@link Castor} constructor.
  *
  * Both built-in methods (`PrismDIDMethod`, `PeerDIDMethod`) and custom
- * third-party methods implement this interface.
+ * third-party methods implement this interface. Payload positions use
+ * `any` so that each concrete `DIDMethod<...>` implementation — with its
+ * own strongly-typed payloads — remains assignable to `DIDMethodInput`
+ * without Castor needing structural casts to invoke lifecycle operations.
+ *
+ * The public API keeps full type safety because `CreatePayloadOf`,
+ * `PublishPayloadOf`, etc. are resolved against each method's concrete
+ * type (captured by Castor's `Extras` tuple), not against this erased shape.
  */
 export interface DIDMethodInput {
   /** The DID method name (e.g. `"prism"`, `"peer"`). */
   method: string;
   /** A resolver capable of resolving DIDs of this method. */
   resolver: Domain.DIDResolver;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  create: (opts: any) => Promise<Domain.DID>;
+  verifySignature: (did: Domain.DID, challenge: Uint8Array, signature: Uint8Array) => Promise<boolean>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  publish?: (opts: any) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  update?: (opts: any) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  deactivate?: (opts: any) => Promise<any>;
 }

--- a/packages/lib/sdk/src/castor/utils/index.ts
+++ b/packages/lib/sdk/src/castor/utils/index.ts
@@ -2,7 +2,6 @@ import * as Domain from '@hyperledger/identus-domain';
 import { base58btc } from "multiformats/bases/base58";
 
 import { CastorError, DIDDocument, type OctetPublicKey, type PublicKey, VerificationMaterialAgreement, VerificationMaterialFormatDID, VerificationMethodTypeAgreement, type VerificationMaterial, VerificationMaterialAuthentication, KeyProperties, Curve, VerificationMethodTypeAuthentication } from "@hyperledger/identus-domain";
-import { type DIDMethods } from "../methods/types";
 import { PrismDIDMethod } from "../methods/prism";
 import { PeerDIDMethod } from "../methods/peer";
 import { type DIDMethodInput } from '../types';
@@ -10,16 +9,15 @@ import { JWKHelper } from './JWKHelper';
 import { MultiCodec } from './Multicodec';
 
 
-
-function toMethodRecord(methods: DIDMethodInput[]): Partial<DIDMethods> {
-    const record: Partial<Record<string, DIDMethodInput>> = {};
+function toMethodRecord(methods: readonly DIDMethodInput[]): Record<string, DIDMethodInput> {
+    const record: Record<string, DIDMethodInput> = {};
     for (const m of methods) {
         record[m.method] = m;
     }
-    return record as Partial<DIDMethods>;
+    return record;
 }
 
-function getDefaultMethods(): DIDMethodInput[] {
+function getDefaultMethods(): readonly DIDMethodInput[] {
     return [
         new PrismDIDMethod(),
         new PeerDIDMethod(),
@@ -32,8 +30,8 @@ function getDefaultMethods(): DIDMethodInput[] {
  */
 export function parseParams(
     apollo: Domain.Apollo,
-    extraMethods: DIDMethodInput[] = [],
-): { apollo: Domain.Apollo; didMethods: Partial<DIDMethods> } {
+    extraMethods: readonly DIDMethodInput[] = [],
+): { apollo: Domain.Apollo; didMethods: Record<string, DIDMethodInput> } {
     return {
         apollo,
         didMethods: toMethodRecord([...getDefaultMethods(), ...extraMethods]),

--- a/packages/lib/sdk/src/edge-agent/Agent.ts
+++ b/packages/lib/sdk/src/edge-agent/Agent.ts
@@ -7,9 +7,15 @@ import {
   type ListenerKey,
 } from "./types";
 import {
-  type DIDMethodTypeMap,
-  type InferCreatePayload,
+  type CreatePayloadOf,
+  type PublishPayloadOf,
+  type UpdatePayloadOf,
+  type DeactivatePayloadOf,
+  type MetadataOf,
+  type MethodMapOf,
 } from "../castor/methods/types";
+import { type PrismDIDMethod, type PeerDIDMethod } from "../castor/methods";
+import { type DIDMethodInput } from "../castor/types";
 
 import { AgentBackup } from "./Agent.Backup";
 import { ConnectionsManager } from "./connections/ConnectionsManager";
@@ -43,12 +49,32 @@ import { HandleOOBInvitation } from "../plugins/internal/didcomm/tasks/HandleOOB
 import { CreatePeerDID } from "./didFunctions";
 
 /**
+ * Map from the DID method names registered on this Agent to their
+ * concrete DID method instance types. Combines the built-in `prism` /
+ * `peer` methods with any extras supplied via `Agent.initialize`.
+ */
+type AgentMethodMap<Extras extends readonly DIDMethodInput[]> =
+  MethodMapOf<readonly [PrismDIDMethod, PeerDIDMethod, ...Extras]>;
+
+/** Registered DID method name on this Agent instance. */
+type AgentMethodName<Extras extends readonly DIDMethodInput[]> =
+  keyof AgentMethodMap<Extras> & string;
+
+/**
  * Edge agent implementation
+ *
+ * The optional tuple type parameter `Extras` carries the concrete types of
+ * any extra DID methods passed to {@link Agent.initialize}, so that
+ * `createDID`, `publishDID`, `updateDID` and `deactivateDID` only accept
+ * method names that are actually registered and infer their payload types
+ * directly from the passed DID method instances.
  *
  * @class Agent
  * @typedef {Agent}
  */
-export class Agent extends Domain.Startable.Controller {
+export class Agent<
+  Extras extends readonly DIDMethodInput[] = readonly []
+> extends Domain.Startable.Controller {
   public backup: AgentBackup;
   public readonly connections: ConnectionsManager;
   public readonly events: EventsManager;
@@ -57,7 +83,7 @@ export class Agent extends Domain.Startable.Controller {
 
   private constructor(
     public readonly apollo: Domain.Apollo,
-    public readonly castor: Domain.Castor,
+    public readonly castor: Castor<Extras>,
     public readonly pluto: Domain.Pluto,
     public readonly mercury: Domain.Mercury,
     public readonly seed: () => Promise<Uint8Array>,
@@ -79,11 +105,17 @@ export class Agent extends Domain.Startable.Controller {
 
   /**
    * Convenience initializer for Agent
-   * allowing default instantiation, omitting all but the absolute necessary parameters
-   * 
+   * allowing default instantiation, omitting all but the absolute necessary parameters.
+   *
+   * DID methods registered through the top-level `didMethods` param are
+   * propagated through to the Agent's type parameter, so `agent.createDID`
+   * and friends are fully typed against them (defaults `"prism" | "peer"`
+   * plus any extras).
+   *
    * @param {Object} params - dependencies object
    * @param {DID | string} params.mediatorDID - did of the mediator to be used
    * @param {Pluto} params.pluto - storage implementation
+   * @param {ReadonlyArray<DIDMethodInput>} [params.didMethods] - custom DID methods to register alongside the built-in prism/peer methods
    * @param {Api} [params.api]
    * @param {Apollo} [params.apollo]
    * @param {Castor} [params.castor]
@@ -91,23 +123,24 @@ export class Agent extends Domain.Startable.Controller {
    * @param {Seed} [params.seed]
    * @returns {Agent}
    */
-  static initialize(params: {
+  static initialize<
+    const ExtraMethods extends readonly DIDMethodInput[] = readonly []
+  >(params: {
     pluto: Domain.Pluto;
+    didMethods?: ExtraMethods;
     mediatorDID?: Domain.DID | string;
     api?: Domain.Api;
     apollo?: Domain.Apollo;
-    castor?: Domain.Castor;
+    castor?: Castor<ExtraMethods>;
     mercury?: Domain.Mercury;
     seed?: () => Promise<Uint8Array>;
     options?: AgentOptions;
-  }): Agent {
+  }): Agent<ExtraMethods> {
     const pluto = params.pluto;
     const api = params.api ?? new FetchApi();
     const apollo = params.apollo ?? new Apollo();
-    const castor = params.castor ?? new Castor(
-      apollo,
-      params.options?.didMethods
-    );
+    const extraMethods = (params.didMethods ?? params.options?.didMethods) as ExtraMethods | undefined;
+    const castor = params.castor ?? new Castor<ExtraMethods>(apollo, extraMethods);
     const didResolver = new DIDCommDIDResolver(castor);
     const secretsResolver = new DIDCommSecretsResolver(apollo, castor, pluto);
     const didcomm = new DIDCommWrapper(didResolver, secretsResolver);
@@ -115,7 +148,7 @@ export class Agent extends Domain.Startable.Controller {
     const mediatorDID = Domain.notNil(params.mediatorDID) ? Domain.DID.from(params.mediatorDID) : undefined;
     const seed = params.seed ?? (async () => apollo.createRandomSeed().seed.value);
 
-    const agent = new Agent(
+    const agent = new Agent<ExtraMethods>(
       apollo,
       castor,
       pluto,
@@ -245,7 +278,12 @@ export class Agent extends Domain.Startable.Controller {
    * Create a new DID using the specified method, store it in Pluto,
    * and (for peer DIDs) update the mediator key list.
    *
-   * @typeParam M - registered DID method name (e.g. `"prism"`, `"peer"`)
+   * The method name is statically checked against the DID methods actually
+   * registered on this Agent (the built-in `prism` / `peer` plus any
+   * custom ones supplied via {@link Agent.initialize}) and the payload
+   * type is inferred directly from the matching DID method instance.
+   *
+   * @typeParam M - registered DID method name (e.g. `"prism"`, `"peer"`, or a custom method)
    * @param method - the DID method to use
    * @param opts - method-specific creation options; may include an optional
    *   `alias` string that is persisted alongside the DID
@@ -266,12 +304,12 @@ export class Agent extends Domain.Startable.Controller {
    * });
    * ```
    */
-  createDID<M extends keyof DIDMethodTypeMap>(
+  createDID<M extends AgentMethodName<Extras>>(
     method: M,
-    opts: InferCreatePayload<M> & { alias?: string },
+    opts: CreatePayloadOf<AgentMethodMap<Extras>[M]> & { alias?: string },
   ): Promise<Domain.DID> {
     if (method === 'prism') {
-      const prismOpts = opts as InferCreatePayload<"prism">;
+      const prismOpts = opts as unknown as CreatePayloadOf<PrismDIDMethod> & { alias?: string };
       if (!prismOpts.keys?.MASTER_KEY) {
         throw new Error("MASTER_KEY is required");
       }
@@ -280,7 +318,7 @@ export class Agent extends Domain.Startable.Controller {
     }
 
     if (method === 'peer') {
-      const peerOpts = opts as InferCreatePayload<"peer">;
+      const peerOpts = opts as unknown as CreatePayloadOf<PeerDIDMethod>;
       const task = new DIDfns.CreatePeerDID({
         ...peerOpts,
         services: peerOpts.services ?? [],
@@ -289,7 +327,48 @@ export class Agent extends Domain.Startable.Controller {
       return this.runTask(task);
     }
 
-    throw new Error(`Method ${method} not supported`);
+    // Delegate custom / user-supplied DID methods to Castor directly.
+    return this.castor.createDID(method, opts);
+  }
+
+  /**
+   * Publish a DID via its registered method.
+   *
+   * The method name and payload are statically checked against the DID
+   * methods registered on this Agent; the return type is the metadata
+   * type declared by the matching DID method instance.
+   */
+  publishDID<M extends AgentMethodName<Extras>>(
+    method: M,
+    opts: PublishPayloadOf<AgentMethodMap<Extras>[M]>,
+  ): Promise<MetadataOf<AgentMethodMap<Extras>[M]>> {
+    return this.castor.publishDID(method, opts);
+  }
+
+  /**
+   * Update a DID via its registered method.
+   *
+   * The method name and payload are statically checked against the DID
+   * methods registered on this Agent.
+   */
+  updateDID<M extends AgentMethodName<Extras>>(
+    method: M,
+    opts: UpdatePayloadOf<AgentMethodMap<Extras>[M]>,
+  ): Promise<MetadataOf<AgentMethodMap<Extras>[M]>> {
+    return this.castor.updateDID(method, opts);
+  }
+
+  /**
+   * Deactivate a DID via its registered method.
+   *
+   * The method name and payload are statically checked against the DID
+   * methods registered on this Agent.
+   */
+  deactivateDID<M extends AgentMethodName<Extras>>(
+    method: M,
+    opts: DeactivatePayloadOf<AgentMethodMap<Extras>[M]>,
+  ): Promise<MetadataOf<AgentMethodMap<Extras>[M]>> {
+    return this.castor.deactivateDID(method, opts);
   }
 
   /**

--- a/packages/lib/sdk/src/edge-agent/didFunctions/CreatePrismDIDWithKeys.ts
+++ b/packages/lib/sdk/src/edge-agent/didFunctions/CreatePrismDIDWithKeys.ts
@@ -1,10 +1,10 @@
 import { type DID } from "@hyperledger/identus-domain";
-import { type InferCreatePayload } from "../../castor/methods/types";
+import { type CreatePayload as PrismCreatePayload } from "../../castor/methods/prism";
 
 import { Task } from "../../utils/tasks";
 import { type AgentContext } from "../Context";
 
-export type Args = InferCreatePayload<"prism"> & {
+export type Args = PrismCreatePayload & {
   alias?: string;
 };
 

--- a/packages/lib/sdk/src/edge-agent/types.ts
+++ b/packages/lib/sdk/src/edge-agent/types.ts
@@ -51,6 +51,12 @@ export type AgentOptions = {
   experiments?: {
     liveMode?: boolean;
   };
+  /**
+   * @deprecated Pass `didMethods` directly at the top level of
+   * `Agent.initialize({ pluto, didMethods, ... })` instead. The top-level
+   * form participates in type inference so `agent.createDID` sees your
+   * custom methods.
+   */
   didMethods?: DIDMethodInput[]
 };
 

--- a/packages/lib/sdk/tests/agent/Agent.anoncreds.test.ts
+++ b/packages/lib/sdk/tests/agent/Agent.anoncreds.test.ts
@@ -14,7 +14,6 @@ import {
   Message,
   Seed,
   StorableCredential,
-  Castor as CastorType
 } from '@hyperledger/identus-domain';
 import { base64url } from "multiformats/bases/base64";
 import { DIDCommProtocol } from "../../src/mercury/DIDCommProtocol";
@@ -30,7 +29,7 @@ import { AnonCredsCredential } from '../../src/plugins/internal/anoncreds';
 
 let agent: Agent;
 let pluto: IPluto;
-let castor: CastorType;
+let castor: Castor;
 
 let api: Api;
 

--- a/packages/lib/sdk/tests/agent/Agent.test.ts
+++ b/packages/lib/sdk/tests/agent/Agent.test.ts
@@ -16,7 +16,6 @@ import {
   Message,
   MessageDirection,
   StorableCredential,
-  Castor as CastorType,
   AgentError,
   PrivateKey
 } from '@hyperledger/identus-domain';
@@ -38,7 +37,7 @@ import { AnonCredsCredential } from '../../src/plugins/internal/anoncreds';
 let agent: Agent;
 let apollo: Apollo;
 let pluto: IPluto;
-let castor: CastorType;
+let castor: Castor;
 let api: Api;
 
 

--- a/packages/lib/sdk/tests/agent/mocks/CastorMock.ts
+++ b/packages/lib/sdk/tests/agent/mocks/CastorMock.ts
@@ -1,14 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { DID, DIDDocument, Castor } from '@hyperledger/identus-domain';
-import {
-  type DIDMethodTypeMap,
-  type InferCreatePayload,
-  type InferPublishPayload,
-  type InferUpdatePayload,
-  type InferDeactivatePayload,
-  type DIDMethodOperation,
-  type InferMetadata,
-} from '../../../src/castor/methods/types';
 
 const castorVars = {
   _prismDID: new DID("did", "peer", "test"),
@@ -22,31 +13,19 @@ const castorVars = {
 export const CastorMock: Castor & typeof castorVars = {
   ...castorVars,
 
-  async createDID<M extends keyof DIDMethodTypeMap>(
-    _method: M,
-    _opts: InferCreatePayload<M>
-  ): Promise<DID> {
+  async createDID(_method: string, _opts: unknown): Promise<DID> {
     return castorVars._prismDID;
   },
 
-  async publishDID<M extends keyof DIDMethodTypeMap>(
-    _method: M,
-    _opts: InferPublishPayload<M>
-  ): Promise<DIDMethodOperation<InferMetadata<M>>> {
+  async publishDID(_method: string, _opts: unknown): Promise<unknown> {
     throw new Error("Method not implemented.");
   },
 
-  async updateDID<M extends keyof DIDMethodTypeMap>(
-    _method: M,
-    _opts: InferUpdatePayload<M>
-  ): Promise<DIDMethodOperation<InferMetadata<M>>> {
+  async updateDID(_method: string, _opts: unknown): Promise<unknown> {
     throw new Error("Method not implemented.");
   },
 
-  async deactivateDID<M extends keyof DIDMethodTypeMap>(
-    _method: M,
-    _opts: InferDeactivatePayload<M>
-  ): Promise<DIDMethodOperation<InferMetadata<M>>> {
+  async deactivateDID(_method: string, _opts: unknown): Promise<unknown> {
     throw new Error("Method not implemented.");
   },
 

--- a/packages/shared/domain/src/buildingBlocks/Castor.ts
+++ b/packages/shared/domain/src/buildingBlocks/Castor.ts
@@ -24,8 +24,9 @@ export type RequiredPrismDIDKeys<
  * Identifiers across multiple DID methods.
  *
  * The concrete SDK implementation ({@link @hyperledger/identus-sdk!Castor})
- * narrows these signatures using the augmentable `DIDMethodTypeMap`
- * exported from `@hyperledger/identus-sdk`.
+ * narrows these signatures by inferring the payload and metadata types
+ * directly from the DID method instances registered on that Castor, so
+ * `createDID`, `publishDID`, etc. are fully typed per method.
  */
 export interface Castor {
   createDID(method: string, opts: unknown): Promise<DID>;

--- a/packages/shared/domain/src/models/DIDDocument.ts
+++ b/packages/shared/domain/src/models/DIDDocument.ts
@@ -236,8 +236,15 @@ export class DIDDocument {
     DIDDocument.parseVerificationMethodGroup(didDocumentJson.assertionMethod, didDocumentJson.verificationMethod, assertionMethod);
     DIDDocument.parseVerificationMethodGroup(didDocumentJson.keyAgreement, didDocumentJson.verificationMethod, keyAgreement);
 
+    const didDocumentServices = didDocumentJson.service ?? []
     const servicesProperty =
-      new DIDDocument.Services(didDocumentJson.service);
+      new DIDDocument.Services(
+        didDocumentServices.map((service: any) => new DIDDocument.Service(
+          service.id,
+          service.type,
+          service.serviceEndpoint
+        ))
+      );
     const verificationMethodsProperty =
       new DIDDocument.VerificationMethods(didDocumentJson.verificationMethod);
 
@@ -380,14 +387,17 @@ export namespace DIDDocument {
 
     constructor(
       public id: string,
-      public type: Array<string>,
+      public type: Array<string> | string,
       endpoint: ServiceEndpoint | string,
     ) {
       this.serviceEndpoint = isString(endpoint) ? new ServiceEndpoint(endpoint) : endpoint;
     }
 
     get isDIDCommMessaging(): boolean {
-      return this.type.includes("DIDCommMessaging");
+      if (typeof this.type === "string") {
+        return this.type === "DIDCommMessaging";
+      }
+      return this.type.includes("DIDCommMessaging")
     }
   }
 


### PR DESCRIPTION
### Description
Improves type-safety of the edge-agent which know knows that there's prism and peer did resolvers and which payload needs to be sent on each case.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
