### PR TITLE
fix: refactor Apollo and Pluto to keep track of the keyProperties whe…

### DIFF
--- a/packages/lib/sdk/src/apollo/Apollo.ts
+++ b/packages/lib/sdk/src/apollo/Apollo.ts
@@ -422,32 +422,77 @@ export class Apollo implements ApolloInterface, KeyRestoration {
   }
 
   restorePrivateKey(key: StorableKey): PrivateKey {
-    switch (key.recoveryId) {
-      case "secp256k1+priv":
-        return new Secp256k1PrivateKey(key.raw);
+    // Old keys have StorableKey.raw with the buffer, new keys use encoded key specification
+    const keySpecificationBuffer = key.data ?? Buffer.from('{}');
+    const keySpecification: Record<string, string> = JSON.parse(keySpecificationBuffer.toString());
+    const rawHex = keySpecification[KeyProperties.rawKey];
+    const raw = key.raw ?? (typeof rawHex === "string" ? Buffer.from(rawHex, "hex") : undefined);
 
-      case "ed25519+priv":
-        return new Ed25519PrivateKey(key.raw);
-
-      case "x25519+priv":
-        return new X25519PrivateKey(key.raw);
+    if (!raw) {
+      throw new ApolloError.KeyRestoratonFailed(key);
     }
 
-    throw new ApolloError.KeyRestoratonFailed(key);
+    let privateKey: PrivateKey | undefined;
+    switch (key.recoveryId) {
+      case "secp256k1+priv":
+        privateKey = new Secp256k1PrivateKey(raw);
+        break;
+      case "ed25519+priv":
+        privateKey = new Ed25519PrivateKey(raw);
+        break;
+      case "x25519+priv":
+        privateKey = new X25519PrivateKey(raw);
+        break;
+    }
+
+    if (!privateKey) {
+      throw new ApolloError.KeyRestoratonFailed(key);
+    }
+
+    for (const [prop, value] of Object.entries(keySpecification)) {
+      if (prop === KeyProperties.rawKey) continue;
+      if (value !== undefined && value !== null) {
+        privateKey.keySpecification.set(prop, String(value));
+      }
+    }
+
+    return privateKey;
   }
 
   restorePublicKey(key: StorableKey): PublicKey {
-    switch (key.recoveryId) {
-      case "secp256k1+pub":
-        return new Secp256k1PublicKey(key.raw);
+    const keySpecificationBuffer = key.data ?? Buffer.from('{}');
+    const keySpecification: Record<string, string> = JSON.parse(keySpecificationBuffer.toString());
+    const rawHex = keySpecification[KeyProperties.rawKey];
+    const raw = key.raw ?? (typeof rawHex === "string" ? Buffer.from(rawHex, "hex") : undefined);
 
-      case "ed25519+pub":
-        return new Ed25519PublicKey(key.raw);
-
-      case "x25519+pub":
-        return new X25519PublicKey(key.raw);
+    if (!raw) {
+      throw new ApolloError.KeyRestoratonFailed(key);
     }
 
-    throw new ApolloError.KeyRestoratonFailed(key);
+    let publicKey: PublicKey | undefined;
+    switch (key.recoveryId) {
+      case "secp256k1+pub":
+        publicKey = new Secp256k1PublicKey(raw);
+        break;
+      case "ed25519+pub":
+        publicKey = new Ed25519PublicKey(raw);
+        break;
+      case "x25519+pub":
+        publicKey = new X25519PublicKey(raw);
+        break;
+    }
+
+    if (!publicKey) {
+      throw new ApolloError.KeyRestoratonFailed(key);
+    }
+
+    for (const [prop, value] of Object.entries(keySpecification)) {
+      if (prop === KeyProperties.rawKey) continue;
+      if (value !== undefined && value !== null) {
+        publicKey.keySpecification.set(prop, String(value));
+      }
+    }
+
+    return publicKey;
   }
 }

--- a/packages/lib/sdk/src/pluto/models/Key.ts
+++ b/packages/lib/sdk/src/pluto/models/Key.ts
@@ -1,5 +1,7 @@
+import { type MigrationPathsForSchema } from "@trust0/ridb-core";
 import type { Model } from "../types";
 import { schemaFactory } from "../utils";
+import { KeyProperties } from "@hyperledger/identus-domain";
 
 /**
  * Definition for Key model
@@ -12,22 +14,53 @@ import { schemaFactory } from "../utils";
 export interface Key extends Model {
   recoveryId: string;
   /**
-   * Hex encoded Key.raw
+   * All recorded key properties in a JSON string
    */
-  rawHex: string;
+  data: string;
   /**
-   * Optional name
+   * Optional alias for searching
    */
   alias?: string;
+  /**
+   * Optional index to search by keyIndex
+   */
   index?: number;
 }
 
 export const KeySchema = schemaFactory<Key>(schema => {
   schema.addProperty("string", "recoveryId");
-  schema.addProperty("string", "rawHex");
   schema.addProperty("string", "alias");
   schema.addProperty("number", "index");
-  schema.setEncrypted("rawHex");
-  schema.setRequired("recoveryId", "rawHex");
-  schema.setVersion(0);
+  schema.addProperty("string", "data");
+
+  schema.setEncrypted("data");
+  schema.setRequired("recoveryId", "data");
+  schema.setVersion(1);
 });
+
+
+export const KeyMigration: MigrationPathsForSchema<typeof KeySchema> = {
+  1: function (document) {
+    const legacy = document as Record<string, unknown> & { rawHex?: string };
+    const data: Record<string, string> = {};
+
+    if (typeof legacy.rawHex === "string") {
+      data[KeyProperties.rawKey] = legacy.rawHex;
+    }
+
+    for (const prop of Object.values(KeyProperties)) {
+      const value = legacy[prop];
+      if (typeof value === "string") {
+        data[prop] = value;
+      } else if (typeof value === "number") {
+        data[prop] = String(value);
+      }
+    }
+
+    const { rawHex: _rawHex, ...rest } = legacy;
+    return {
+      ...rest,
+      data: JSON.stringify(data),
+    } as unknown as ReturnType<NonNullable<MigrationPathsForSchema<typeof KeySchema>[1]>>;
+  }
+};

--- a/packages/lib/sdk/src/pluto/repositories/KeyRepository.ts
+++ b/packages/lib/sdk/src/pluto/repositories/KeyRepository.ts
@@ -23,13 +23,11 @@ export class KeyRepository extends MapperRepository<"keys", Domain.PrivateKey> {
   toDomain(model: Models.Key): Domain.PrivateKey {
     const domain = this.keyRestoration.restorePrivateKey({
       ...model,
-      raw: Buffer.from(model.rawHex, "hex"),
+      data: Buffer.from(model.data),
     });
-
-    if (model.index != undefined) {
+    if (model.index != undefined && !domain.keySpecification.has(Domain.KeyProperties.index)) {
       domain.keySpecification.set(Domain.KeyProperties.index, model.index.toString());
     }
-
     return this.withId(domain, model.uuid);
   }
 
@@ -40,9 +38,8 @@ export class KeyRepository extends MapperRepository<"keys", Domain.PrivateKey> {
     return {
       uuid: domain.uuid,
       recoveryId: domain.recoveryId,
-      rawHex: domain.to.String("hex"),
       index: domain.index,
-
+      data: Buffer.from(domain.data).toString(),
     };
   }
 }

--- a/packages/lib/sdk/src/pluto/repositories/LinkSecretRepository.ts
+++ b/packages/lib/sdk/src/pluto/repositories/LinkSecretRepository.ts
@@ -2,6 +2,7 @@ import * as Domain from "@hyperledger/identus-domain";
 import type * as Models from "../models";
 import type { Pluto } from "../Pluto";
 import { MapperRepository } from "./builders/MapperRepository";
+import { KeyProperties } from "@hyperledger/identus-domain";
 
 export class LinkSecretRepository extends MapperRepository<"keys", Domain.LinkSecret> {
   baseModel = {
@@ -13,9 +14,9 @@ export class LinkSecretRepository extends MapperRepository<"keys", Domain.LinkSe
   }
 
   toDomain(model: Models.Key): Domain.LinkSecret {
-    const secret = Buffer.from(model.rawHex, "hex").toString();
+    const keySpecification = JSON.parse(model.data);
+    const secret = Buffer.from(keySpecification[KeyProperties.rawKey], "hex").toString();
     const domain = new Domain.LinkSecret(secret, model.alias);
-
     return this.withId(domain, model.uuid);
   }
 
@@ -23,8 +24,10 @@ export class LinkSecretRepository extends MapperRepository<"keys", Domain.LinkSe
     return {
       ...this.baseModel,
       uuid: domain.uuid,
-      rawHex: Buffer.from(domain.secret).toString("hex"),
-      alias: domain.name
+      alias: domain.name,
+      data: JSON.stringify({
+        [KeyProperties.rawKey]: Buffer.from(domain.secret).toString("hex")
+      })
     };
   }
 }

--- a/packages/lib/sdk/src/pluto/store/index.ts
+++ b/packages/lib/sdk/src/pluto/store/index.ts
@@ -64,7 +64,7 @@ export const createStore = async (dbName: string, options: StartOptions = {}): P
             credentials: Models.CredentialMigration,
             "credential-metadata": {},
             dids: {},
-            keys: {},
+            keys: Models.KeyMigration,
             messages: Models.MessageMigration,
             "didkey-link": {},
             "did-link": {},

--- a/packages/lib/sdk/tests/pluto/Pluto.Keys.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.Keys.test.ts
@@ -28,5 +28,109 @@ describe("Pluto", () => {
       expect(sut.uuid).to.be.a.string;
       expect(sut.uuid).to.eql(uuid);
     });
+
+    describe("keySpecification round-trip via storeDID + getDIDPrivateKeysByDID", () => {
+      const retrieveKey = async (key: SDK.Domain.PrivateKey) => {
+        const did = SDK.Domain.DID.from(`did:prism:${randomUUID().replace(/-/g, "")}`);
+        await instance.storeDID(did, key);
+        const keys = await instance.getDIDPrivateKeysByDID(did);
+        expect(keys).to.have.length(1);
+        return keys[0];
+      };
+
+      test("Secp256k1PrivateKey - raw, curve, recoveryId, size, type preserved", async () => {
+        const sut = new SDK.Secp256k1PrivateKey(Fixtures.Keys.secp256K1.privateKey.raw);
+
+        const restored = await retrieveKey(sut);
+
+        expect(restored).to.be.instanceOf(SDK.Secp256k1PrivateKey);
+        expect(restored.uuid).to.eql(sut.uuid);
+        expect(restored.raw).to.eql(sut.raw);
+        expect(restored.curve).to.eql(sut.curve);
+        expect(restored.size).to.eql(sut.size);
+        expect(restored.type).to.eql(sut.type);
+        expect(restored.keySpecification).to.eql(sut.keySpecification);
+      });
+
+      test("Ed25519PrivateKey - raw, curve, recoveryId, size, type preserved", async () => {
+        const sut = new SDK.Ed25519PrivateKey(Fixtures.Keys.ed25519.privateKey.raw);
+
+        const restored = await retrieveKey(sut);
+
+        expect(restored).to.be.instanceOf(SDK.Ed25519PrivateKey);
+        expect(restored.uuid).to.eql(sut.uuid);
+        expect(restored.raw).to.eql(sut.raw);
+        expect(restored.curve).to.eql(sut.curve);
+        expect(restored.size).to.eql(sut.size);
+        expect(restored.type).to.eql(sut.type);
+        expect(restored.keySpecification).to.eql(sut.keySpecification);
+      });
+
+      test("X25519PrivateKey - raw, curve, recoveryId, size, type preserved", async () => {
+        const sut = new SDK.X25519PrivateKey(Fixtures.Keys.x25519.privateKey.raw);
+
+        const restored = await retrieveKey(sut);
+
+        expect(restored).to.be.instanceOf(SDK.X25519PrivateKey);
+        expect(restored.uuid).to.eql(sut.uuid);
+        expect(restored.raw).to.eql(sut.raw);
+        expect(restored.curve).to.eql(sut.curve);
+        expect(restored.size).to.eql(sut.size);
+        expect(restored.type).to.eql(sut.type);
+        expect(restored.keySpecification).to.eql(sut.keySpecification);
+      });
+
+      test("Custom keySpecification entries (chainCode, derivationPath, index) are preserved", async () => {
+        const sut = new SDK.Secp256k1PrivateKey(Fixtures.Keys.secp256K1.privateKey.raw);
+        sut.keySpecification.set(SDK.Domain.KeyProperties.chainCode, "abcd1234");
+        sut.keySpecification.set(SDK.Domain.KeyProperties.derivationPath, Buffer.from("m/0'/0'/0'").toString("hex"));
+        sut.keySpecification.set(SDK.Domain.KeyProperties.index, "3");
+        sut.keySpecification.set(SDK.Domain.KeyProperties.seed, "deadbeef");
+
+        const restored = await retrieveKey(sut);
+
+        expect(restored.raw).to.eql(sut.raw);
+        expect(restored.keySpecification).to.eql(sut.keySpecification);
+        expect(restored.getProperty(SDK.Domain.KeyProperties.chainCode)).to.eql("abcd1234");
+        expect(restored.getProperty(SDK.Domain.KeyProperties.derivationPath)).to.eql(Buffer.from("m/0'/0'/0'").toString("hex"));
+        expect(restored.getProperty(SDK.Domain.KeyProperties.index)).to.eql("3");
+        expect(restored.getProperty(SDK.Domain.KeyProperties.seed)).to.eql("deadbeef");
+      });
+
+      test("keySpecification does not leak raw key property", async () => {
+        const sut = new SDK.Ed25519PrivateKey(Fixtures.Keys.ed25519.privateKey.raw);
+
+        const restored = await retrieveKey(sut);
+
+        expect(restored.keySpecification.has(SDK.Domain.KeyProperties.rawKey)).to.eql(false);
+      });
+
+      test("Derived Secp256k1 key round-trips keySpecification produced by derive()", async () => {
+        const parent = new SDK.Secp256k1PrivateKey(Fixtures.Keys.secp256K1.privateKey.raw);
+        parent.keySpecification.set(SDK.Domain.KeyProperties.chainCode, Buffer.alloc(32, 1).toString("hex"));
+        const sut = parent.derive("m/0'/0'/0'");
+
+        const restored = await retrieveKey(sut);
+
+        expect(restored.raw).to.eql(sut.raw);
+        expect(restored.keySpecification).to.eql(sut.keySpecification);
+        expect(restored.getProperty(SDK.Domain.KeyProperties.derivationPath)).to.eql(sut.getProperty(SDK.Domain.KeyProperties.derivationPath));
+        expect(restored.getProperty(SDK.Domain.KeyProperties.chainCode)).to.eql(sut.getProperty(SDK.Domain.KeyProperties.chainCode));
+        expect(restored.getProperty(SDK.Domain.KeyProperties.index)).to.eql(sut.getProperty(SDK.Domain.KeyProperties.index));
+      });
+
+      test("Restored key is functionally equivalent - sign verifies with original publicKey", async () => {
+        const sut = new SDK.Ed25519PrivateKey(Fixtures.Keys.ed25519.privateKey.raw);
+
+        const restored = await retrieveKey(sut);
+
+        expect(restored.isSignable()).to.eql(true);
+        const message = Buffer.from("round-trip-signature-check");
+        const signature = (restored as SDK.Ed25519PrivateKey).sign(message);
+        const publicKey = sut.publicKey();
+        expect(publicKey.canVerify()).to.eql(true);
+        expect(publicKey.verify(message, signature)).to.eql(true);
+      });
+    });
   });
 });

--- a/packages/shared/domain/src/models/keyManagement/Key.ts
+++ b/packages/shared/domain/src/models/keyManagement/Key.ts
@@ -24,8 +24,13 @@ export abstract class Key {
   abstract getEncoded(): Uint8Array;
 
   get curve() {
-
     return this.getProperty(KeyProperties.curve)!;
+  }
+
+  get data(): Uint8Array {
+    const payload = Object.fromEntries(this.keySpecification);
+    payload[KeyProperties.rawKey] = Buffer.from(this.raw).toString("hex");
+    return Buffer.from(JSON.stringify(payload));
   }
 
   get alg(): JWT_ALG {

--- a/packages/shared/domain/src/models/keyManagement/StorableKey.ts
+++ b/packages/shared/domain/src/models/keyManagement/StorableKey.ts
@@ -1,7 +1,8 @@
 
 export interface StorableKey {
   recoveryId: string;
-  raw: Uint8Array;
+  raw?: Uint8Array;
+  data: Uint8Array;
   index?: number;
 }
 


### PR DESCRIPTION
### Description

When storing and restoring a key from storage we should be able to extract and store the keySpecification keys.
No other changes

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
