### PR TITLE
fix(pluto): restore SD+JWT disclosures on backup restore

### DIFF
--- a/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Restore.ts
+++ b/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Restore.ts
@@ -4,6 +4,7 @@ import { Secp256k1PrivateKey } from "../../../../apollo/utils/Secp256k1PrivateKe
 import { X25519PrivateKey } from "../../../../apollo/utils/X25519PrivateKey";
 import { AnonCredsCredential } from "../../../../plugins/internal/anoncreds";
 import { JWTCredential } from "../../../../pollux/models/JWTVerifiableCredential";
+import { SDJWTCredential } from "../../../../pollux/models/SDJWTVerifiableCredential";
 import { notEmptyString, notNil } from "../../../../utils";
 import { type IRestoreTask } from "../interfaces";
 import { base64url } from "multiformats/bases/base64";
@@ -33,7 +34,7 @@ export class RestoreTask implements IRestoreTask {
         return JWTCredential.fromJWS(decoded);
       }
       if (item.recovery_id === "sdjwt") {
-        return JWTCredential.fromJWS(decoded);
+        return SDJWTCredential.fromJWS(decoded);
       }
       if (item.recovery_id === "anoncred") {
         return AnonCredsCredential.fromJson(decoded);

--- a/packages/lib/sdk/src/pollux/models/SDJWTVerifiableCredential.ts
+++ b/packages/lib/sdk/src/pollux/models/SDJWTVerifiableCredential.ts
@@ -188,6 +188,8 @@ export class SDJWTCredential extends Credential implements ProvableCredential, S
                 claims[disclosure.key] = disclosure;
             }
         }
-        return new SDJWTCredential(loaded, [claims], revoked);
+        const result = new SDJWTCredential(loaded, [claims], revoked);
+        result.properties.set(JWT.Claims.jti, jws);
+        return result;
     }
 }

--- a/packages/lib/sdk/src/pollux/models/SDJWTVerifiableCredential.ts
+++ b/packages/lib/sdk/src/pollux/models/SDJWTVerifiableCredential.ts
@@ -90,7 +90,7 @@ export class SDJWTCredential extends Credential implements ProvableCredential, S
             this.properties.set(JWT.Claims.sub, payload.sub);
         }
 
-        this.properties.set(JWT.Claims.jti, jwt.encodeJwt());
+        this.properties.set(JWT.Claims.jti, object.encodeSDJwt());
 
         if (payload.nbf) {
             this.properties.set(JWT.Claims.nbf, payload.nbf);

--- a/packages/lib/sdk/tests/fixtures/backup.ts
+++ b/packages/lib/sdk/tests/fixtures/backup.ts
@@ -1,13 +1,15 @@
 import { base64url } from "multiformats/bases/base64";
 
-import { Apollo, BackupOptions, Domain, JWTCredential, Secp256k1PrivateKey } from "../../src";
+import { Apollo, BackupOptions, Domain, JWTCredential, SDJWTCredential, Secp256k1PrivateKey } from "../../src";
 import { LinkSecret, Mediator, Message, Schema } from '@hyperledger/identus-domain';
 import { credentialPayloadEncoded } from "./credentials/jwt";
+import { credentialPayloadWithDisclosures } from "./credentials/sdjwt";
 import { credential as anonCredential } from "./credentials/anoncreds";
 import { peerDID4, peerDID5 } from "./dids";
 import { AnonCredsCredential } from "../../src/plugins/internal/anoncreds";
 
 export const credentialJWT = JWTCredential.fromJWS(credentialPayloadEncoded);
+export const credentialSDJWT: SDJWTCredential = SDJWTCredential.fromJWS(credentialPayloadWithDisclosures);
 export const credentialAnoncreds = new AnonCredsCredential(anonCredential);
 export const hostDID = peerDID5;
 export const targetDID = peerDID4;
@@ -56,6 +58,10 @@ export const backups: { title: string, json: Schema, options: BackupOptions, jwe
         {
           recovery_id: "anoncred",
           data: Buffer.from(base64url.baseEncode(Buffer.from(credentialAnoncreds.toStorable().credentialData))).toString(),
+        },
+        {
+          recovery_id: 'sdjwt',
+          data: Buffer.from(base64url.baseEncode(Buffer.from(credentialPayloadWithDisclosures))).toString(),
         }
       ],
       dids: [
@@ -107,6 +113,10 @@ export const backups: { title: string, json: Schema, options: BackupOptions, jwe
         {
           recovery_id: "anoncred",
           data: Buffer.from(base64url.baseEncode(Buffer.from(credentialAnoncreds.toStorable().credentialData))).toString(),
+        },
+        {
+          recovery_id: 'sdjwt',
+          data: Buffer.from(base64url.baseEncode(Buffer.from(credentialPayloadWithDisclosures))).toString(),
         }
       ],
       dids: [
@@ -160,6 +170,10 @@ export const backups: { title: string, json: Schema, options: BackupOptions, jwe
         {
           recovery_id: "anoncred",
           data: Buffer.from(base64url.baseEncode(Buffer.from(credentialAnoncreds.toStorable().credentialData))).toString(),
+        },
+        {
+          recovery_id: 'sdjwt',
+          data: Buffer.from(base64url.baseEncode(Buffer.from(credentialPayloadWithDisclosures))).toString(),
         }
       ],
       dids: [

--- a/packages/lib/sdk/tests/fixtures/credentials/sdjwt.ts
+++ b/packages/lib/sdk/tests/fixtures/credentials/sdjwt.ts
@@ -1,31 +1,34 @@
-import { AttachmentDescriptor, CredentialType, JWT_ALG } from '@hyperledger/identus-domain';
-
+import { AttachmentDescriptor, CredentialType } from '@hyperledger/identus-domain';
 import { list } from "../dids";
 import { OfferCredential } from '../../../src/plugins/internal/didcomm';
 
 
 export const credentialPayloadEncoded = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6cHJpc206NzE2OGEwN2I5NGQxMzAyNjg5MDU2ZTkyN2I0ZGVmOTNjNDIzYjk1NTNmNzcxZTQ4NmM4ZDkxODg4M2UyNTZmMTpDcTBCQ3FvQkVsc0tIMkYxZEdobGJuUnBZMkYwYVc5dVlYVjBhR1Z1ZEdsallYUnBiMjVMWlhrUUJFSTJDZ2RGWkRJMU5URTVFaXRrYlRWbU1rZGtValZDWVVod1VuaENPR0pVUld4MlJWOHdaMGxETW5BME1EUk5jM2c1YzNkS09URTBFa3NLRDIxaGMzUmxjbTFoYzNSbGNrdGxlUkFCUWpZS0IwVmtNalUxTVRrU0syUnROV1l5UjJSU05VSmhTSEJTZUVJNFlsUkZiSFpGWHpCblNVTXljRFF3TkUxemVEbHpkMG81TVRRIiwiaWF0IjoxNzE3Nzc2MTY3NTg5LCJ2Y3QiOiJodHRwOi8vZXhhbXBsZS5jb20iLCJmaXJzdG5hbWUiOiJKb2huIiwibGFzdG5hbWUiOiJEb2UiLCJzc24iOiIxMjMtNDUtNjc4OSIsImlkIjoiMTIzNCIsIl9zZF9hbGciOiJzaGEtMjU2In0.RThFQjlENjJDN0Y5NjlCOEM0NERFNkU3RDg4MDg5RkRBQjg0RTUzNzUyNTZFRUI5NUQyQTUwQ0U1MTdDNzQ2NjU5REExOTM4Njc0RjhFMkQ2QjFCNzNFNEZCRDZBNkQ4NjIzNDFEQkFERjY0MTBERUJCRENDRkVBRjhCMkMwMDU~";
+export const credentialDisclosure = "WyJzYWx0MTIzIiwiZmlyc3RuYW1lIiwiU0RKV1QiXQ";
+export const credentialPayloadWithDisclosures = credentialPayloadEncoded + credentialDisclosure;
+export const expectedDisclosureKey = "firstname";
+export const expectedDisclosureValue = "SDJWT";
 
 export const credentialOfferMessage = new OfferCredential(
   {
-    // "formats": [
-    //   {
-    //     attach_id: "321905d1-5f01-42b0-b0ba-39b09645eeaa",
-    //     format: CredentialType.SDJWT
-    //   }
-    // ],
+    "formats": [
+      {
+        attach_id: "321905d1-5f01-42b0-b0ba-39b09645eeaa",
+        format: CredentialType.SDJWT
+      }
+    ],
     "credential_preview": {
       "body": {
         "attributes": [
           {
             "media_type": null,
-            "name": "familyName",
-            "value": "JWT"
+            "name": "firstname",
+            "value": "SDJWT"
           },
           {
             "media_type": null,
-            "name": "emailAddress",
-            "value": "jwt@wonderland.com"
+            "name": "lastname",
+            "value": "Wonderland"
           }
         ]
       },

--- a/packages/lib/sdk/tests/pluto/Pluto.Backup.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.Backup.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, test, beforeEach } from 'vitest';
 import * as Fixtures from "../fixtures";
 import { base64url } from 'multiformats/bases/base64';
 import { randomUUID } from 'node:crypto';
-import { Apollo, Domain, JWTCredential, Pluto } from '../../src';
+import { Apollo, Domain, JWTCredential, Pluto, SDJWTCredential, SDJWT_VP_PROPS } from '../../src';
 import { AnonCredsCredential } from '../../src/plugins/internal/anoncreds';
 
 
@@ -193,6 +193,31 @@ describe("Pluto", () => {
         expect(sut.subject).to.eq(Fixtures.Backup.credentialAnoncreds.subject);
       });
 
+      test("credentials - SD-JWT", async () => {
+        const expected = Fixtures.Backup.credentialSDJWT;
+        await instance.restore({
+          credentials: [
+            {
+              recovery_id: 'sdjwt',
+              data: Buffer.from(base64url.baseEncode(Buffer.from(Fixtures.Credentials.SDJWT.credentialPayloadWithDisclosures))).toString(),
+            },
+          ],
+          dids: [],
+          did_pairs: [],
+          keys: [],
+          mediators: [],
+          messages: [],
+          link_secret: undefined,
+        });
+
+        const result = await instance.getAllCredentials();
+        expect(result).to.be.an("array").to.have.length(1);
+        const sut = result[0] as SDJWTCredential;
+        expect(sut).to.be.instanceOf(SDJWTCredential);
+        expect(sut.id).to.eq(expected.id);
+        expect(sut.properties.get(SDJWT_VP_PROPS.disclosures)).to.deep.eq(expected.properties.get(SDJWT_VP_PROPS.disclosures));
+      });
+
       test("dids", async () => {
         await instance.restore({
           credentials: [],
@@ -379,6 +404,7 @@ describe("Pluto", () => {
       test("Backup -> Restore", async () => {
         await instance.storeCredential(Fixtures.Backup.credentialJWT);
         await instance.storeCredential(Fixtures.Backup.credentialAnoncreds);
+        await instance.storeCredential(Fixtures.Backup.credentialSDJWT);
         await instance.storeDIDPair(Fixtures.Backup.hostDID, Fixtures.Backup.targetDID, Fixtures.Backup.pairAlias);
         await instance.storeDID(Fixtures.Backup.hostDID, Fixtures.Backup.peerDIDKeys);
         if (backupFixture.json.version == "0.0.1") {
@@ -409,7 +435,7 @@ describe("Pluto", () => {
 
         expect(dids).not.to.be.null;
 
-        expect(credentials).to.have.length(2);
+        expect(credentials).to.have.length(3);
         // expect(credentials.map(x => (x as any).toStorable())).to.have.deep.members([Fixtures.Backup.credentialAnoncreds.toStorable(), Fixtures.Backup.credentialJWT.toStorable()]);
 
         expect(dids).to.have.length(2);


### PR DESCRIPTION
### Description

Fixes #458 

SD+JWT credentials stored in the wallet were losing their selective disclosure data during backup and restore, making them unusable for presentations after a restore.

The root cause was in SDJWTCredential — when saving the credential, the code called jwt.encodeJwt() to set the credential id, which only returns the bare JWT token. The disclosure fragments were silently dropped. Since everything downstream (backup, credential repository, presentation) reads the id to get the full SD+JWT, all of them were working with an incomplete credential.

On top of that, the restore logic in Restore.ts was using JWTCredential.fromJWS() to parse SD+JWT credentials instead of SDJWTCredential.fromJWS(), which produced a credential object of the completely wrong type with no selective disclosure support.

Files changed:

SDJWTVerifiableCredential.ts — use object.encodeSDJwt() instead of jwt.encodeJwt() to preserve disclosures in the credential id
Restore.ts — use SDJWTCredential.fromJWS() instead of JWTCredential.fromJWS() for sdjwt recovery type

### Alternatives Considered (optional)

I gave a second thought about reconstructing the full SD+JWT from saved parts at backup time instead of fixing the source. But that would require re-encoding the disclosures, which could change the output and break verification on the other end. Fixing the root cause was simpler and safer.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
