### PR TITLE
fix: setup right project priority to fix race condition 

### DIFF
--- a/packages/lib/sdk/project.json
+++ b/packages/lib/sdk/project.json
@@ -1,10 +1,10 @@
 {
   "projectType": "library",
   "implicitDependencies": [
-    "@hyperledger/identus-domain",
     "@hyperledger/identus-didcomm",
-    "@hyperledger/identus-anoncreds",
     "@hyperledger/identus-jwe",
+    "@hyperledger/identus-anoncreds",
+    "@hyperledger/identus-domain",
     "@hyperledger/identus-protos"
   ],
   "tags": [


### PR DESCRIPTION

### Description

Since we moved to workspaces and built this internal dependencies there is an issue where the didcomm package sometimes does not build in time affecting the whole build pipeline.

This simply adds a fix for that, ensuring the 3 rust dependencies build in the right order

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
