### PR TITLE
fix: store and retrieve the derivationPath on keys derived from a seed

### DIFF
--- a/packages/lib/sdk/src/apollo/Apollo.ts
+++ b/packages/lib/sdk/src/apollo/Apollo.ts
@@ -16,6 +16,7 @@ import {
   PrismDerivationPath,
   type KeyOptions,
   isString,
+  type Key,
 } from "@hyperledger/identus-domain";
 
 import { Ed25519PrivateKey } from "./utils/Ed25519PrivateKey";
@@ -69,14 +70,14 @@ function fromSeed(
     }
   }
 
+  const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
 
   if (curve === Curve.ED25519) {
     if (seedBuff) {
       const hdKey = ApolloSDK.derivation.EdHDKey.Companion.initFromSeed(Int8Array.from(seedBuff));
       const baseKey = new Ed25519PrivateKey(Uint8Array.from(hdKey.privateKey));
-      const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
       baseKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(Uint8Array.from(hdKey.chainCode)).toString("hex"));
-      baseKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationParam).toString("hex"));
+      baseKey.keySpecification.set(KeyProperties.derivationPath, derivationParam);
       if (derivationPath) {
         const privateKey = baseKey.derive(derivationParam);
         return privateKey;
@@ -90,13 +91,12 @@ function fromSeed(
 
   if (curve === Curve.X25519) {
     if (seedBuff) {
-      const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
       const hdKey = ApolloSDK.derivation.EdHDKey.Companion.initFromSeed(Int8Array.from(seedBuff)).derive(derivationParam);
       const edKey = Ed25519PrivateKey.from.Buffer(Buffer.from(hdKey.privateKey));
       const xKey = edKey.x25519();
 
       xKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(hdKey.chainCode).toString("hex"));
-      xKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationParam).toString("hex"));
+      xKey.keySpecification.set(KeyProperties.derivationPath, derivationParam);
       xKey.keySpecification.set(KeyProperties.index, `${derivationIndex}`);
 
       return xKey;
@@ -107,7 +107,6 @@ function fromSeed(
   }
 
   if (curve === Curve.SECP256K1) {
-    const derivationParam: string = derivationPath ?? PrismDerivationPath.init(derivationIndex).toString();
     const hdKey = HDKey.InitFromSeed(
       Int8Array.from(seedBuff!),
       derivationParam.split("/").slice(1).length,
@@ -124,7 +123,7 @@ function fromSeed(
 
     const baseKey = new Secp256k1PrivateKey(Uint8Array.from(hdKey.privateKey));
     baseKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(Uint8Array.from(hdKey.chainCode)).toString("hex"));
-    baseKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationParam).toString("hex"));
+    baseKey.keySpecification.set(KeyProperties.derivationPath, derivationParam);
     baseKey.keySpecification.set(KeyProperties.index, `${derivationIndex}`);
 
     if (derivationPath) {
@@ -421,6 +420,16 @@ export class Apollo implements ApolloInterface, KeyRestoration {
     )
   }
 
+  #addKeySpecification<K extends Key>(key: K, keySpecification: Record<string, string>): K {
+    for (const [prop, value] of Object.entries(keySpecification)) {
+      if (prop === KeyProperties.rawKey.toString()) continue;
+      if (value !== undefined && value !== null) {
+        key.keySpecification.set(prop, String(value));
+      }
+    }
+    return key;
+  }
+
   restorePrivateKey(key: StorableKey): PrivateKey {
     // Old keys have StorableKey.raw with the buffer, new keys use encoded key specification
     const keySpecificationBuffer = key.data ?? Buffer.from('{}');
@@ -449,12 +458,7 @@ export class Apollo implements ApolloInterface, KeyRestoration {
       throw new ApolloError.KeyRestoratonFailed(key);
     }
 
-    for (const [prop, value] of Object.entries(keySpecification)) {
-      if (prop === KeyProperties.rawKey) continue;
-      if (value !== undefined && value !== null) {
-        privateKey.keySpecification.set(prop, String(value));
-      }
-    }
+    privateKey = this.#addKeySpecification(privateKey, keySpecification);
 
     return privateKey;
   }
@@ -486,12 +490,7 @@ export class Apollo implements ApolloInterface, KeyRestoration {
       throw new ApolloError.KeyRestoratonFailed(key);
     }
 
-    for (const [prop, value] of Object.entries(keySpecification)) {
-      if (prop === KeyProperties.rawKey) continue;
-      if (value !== undefined && value !== null) {
-        publicKey.keySpecification.set(prop, String(value));
-      }
-    }
+    publicKey = this.#addKeySpecification(publicKey, keySpecification);
 
     return publicKey;
   }

--- a/packages/lib/sdk/src/apollo/utils/Ed25519PrivateKey.ts
+++ b/packages/lib/sdk/src/apollo/utils/Ed25519PrivateKey.ts
@@ -22,13 +22,10 @@ const EdHDKey = ApolloSDK.derivation.EdHDKey;
  */
 export class Ed25519PrivateKey extends PrivateKey implements DerivableKey, ExportableKey, SignableKey, StorableKey {
   public readonly recoveryId = StorableKey.recoveryId("ed25519", "priv");
-
-
   public keySpecification: Map<string, string> = new Map();
   public raw: Uint8Array;
   public size: number;
   public type = KeyTypes.EC;
-
   public readonly to = ExportableKey.factory(this, { pemLabel: "PRIVATE KEY" });
   static from = ImportableKey.factory(Ed25519PrivateKey, { pemLabel: "PRIVATE KEY" });
 
@@ -56,12 +53,11 @@ export class Ed25519PrivateKey extends PrivateKey implements DerivableKey, Expor
     );
     const derived = hdKey.derive(derivationPathStr);
     const sk = new Ed25519PrivateKey(Uint8Array.from(derived.privateKey));
-    sk.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationPathStr).toString("hex"));
+    sk.keySpecification.set(KeyProperties.derivationPath, derivationPathStr);
     sk.keySpecification.set(KeyProperties.index, `${this.index ?? 0}`);
     if (derived.chainCode) {
       sk.keySpecification.set(KeyProperties.chainCode, Buffer.from(derived.chainCode).toString("hex"));
     }
-
     return sk;
   }
 

--- a/packages/lib/sdk/src/apollo/utils/Secp256k1PrivateKey.ts
+++ b/packages/lib/sdk/src/apollo/utils/Secp256k1PrivateKey.ts
@@ -70,7 +70,8 @@ export class Secp256k1PrivateKey
       throw new ApolloError.ApolloLibError("Key generated incorrectly: missing privateKey");
     }
     const privateKey = new Secp256k1PrivateKey(Buffer.from(derivedKey.privateKey));
-    privateKey.keySpecification.set(KeyProperties.derivationPath, Buffer.from(derivationPathStr).toString("hex"));
+    privateKey.keySpecification = new Map(this.keySpecification);
+    privateKey.keySpecification.set(KeyProperties.derivationPath, derivationPathStr);
     privateKey.keySpecification.set(KeyProperties.index, `${this.index ?? 0}`);
     if (derivedKey.chainCode) {
       privateKey.keySpecification.set(KeyProperties.chainCode, Buffer.from(derivedKey.chainCode).toString("hex"));

--- a/packages/lib/sdk/tests/agent/Agent.anoncreds.test.ts
+++ b/packages/lib/sdk/tests/agent/Agent.anoncreds.test.ts
@@ -73,7 +73,7 @@ describe("Agent Tests", () => {
       castor,
       pluto,
       mercury,
-      seed,
+      seed: async () => seed.value,
       api,
     });
 

--- a/packages/lib/sdk/tests/apollo/Apollo.createPrivateKey.test.ts
+++ b/packages/lib/sdk/tests/apollo/Apollo.createPrivateKey.test.ts
@@ -86,7 +86,7 @@ describe("Apollo", () => {
         expect(result.curve).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.curve)).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.chainCode)).to.eq("99f91ece40d2b5ff6896e96fd1e626dd17bc7f21d09538795021318009a1013c");
-        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f30272f30272f3027");
+        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/0'/0'/0'");
         expect(result.getProperty(KeyProperties.index)).to.eq("0");
       });
 
@@ -103,7 +103,7 @@ describe("Apollo", () => {
         expect(result.curve).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.curve)).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.chainCode)).to.eq("fee48c5a862316d1ea59b77258850f64de2a316796db043a4ebca1616c1c0d24");
-        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f31272f30272f3027");
+        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/1'/0'/0'");
         expect(result.getProperty(KeyProperties.index)).to.eq("0");
       });
 
@@ -122,7 +122,7 @@ describe("Apollo", () => {
         expect(result.curve).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.curve)).to.eq(Curve.SECP256K1);
         expect(result.getProperty(KeyProperties.chainCode)).to.eq("6bfbb6d7bee48110dd0dd1437caa9e88dba86e4bc28585e8e8ab052c96414a48");
-        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f32272f30272f3027");
+        expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/2'/0'/0'");
         expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
       });
 

--- a/packages/lib/sdk/tests/apollo/Apollo.test.ts
+++ b/packages/lib/sdk/tests/apollo/Apollo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, test, beforeEach, afterEach } from 'vitest';
 import { Apollo } from "../../src/apollo/Apollo";
 import { Secp256k1KeyPair } from "../../src/apollo/utils/Secp256k1KeyPair";
-import { ECConfig, PrismDerivationPath, DerivationAxis, DeprecatedDerivationPath } from "@hyperledger/identus-domain";
+import { ECConfig, PrismDerivationPath, DerivationAxis, DeprecatedDerivationPath, Key } from "@hyperledger/identus-domain";
 
 import { bip39Vectors } from "./derivation/BipVectors";
 import { DerivationPath } from "../../src/apollo/utils/derivation/DerivationPath";
@@ -392,11 +392,22 @@ describe("Apollo", () => {
   });
 
   describe("KeyRestoration", () => {
+    function getStorableData(key: Key): StorableKey['data'] {
+      const payload = Object.fromEntries(key.keySpecification);
+      for (const [prop, value] of Object.entries(payload)) {
+        if (prop === KeyProperties.rawKey.toString()) continue;
+        if (value !== undefined && value !== null) {
+          payload[prop] = String(value);
+        }
+      }
+      payload[KeyProperties.rawKey] = Buffer.from(key.raw).toString("hex");
+      return Buffer.from(JSON.stringify(payload));
+    }
     describe("restorePrivateKey", () => {
       test("recoveryId ed25519+priv - matches - returns Ed25519PrivateKey instance", () => {
         const key: StorableKey = {
           recoveryId: StorableKey.recoveryId("ed25519", "priv"),
-          raw: Fixtures.Keys.ed25519.privateKey.raw
+          data: getStorableData(Fixtures.Keys.ed25519.privateKey)
         };
 
         const result = apollo.restorePrivateKey(key);
@@ -407,7 +418,7 @@ describe("Apollo", () => {
       test("recoveryId x25519+priv - matches - returns X25519PrivateKey instance", () => {
         const key: StorableKey = {
           recoveryId: StorableKey.recoveryId("x25519", "priv"),
-          raw: Fixtures.Keys.x25519.privateKey.raw
+          data: getStorableData(Fixtures.Keys.x25519.privateKey)
         };
 
         const result = apollo.restorePrivateKey(key);
@@ -418,7 +429,7 @@ describe("Apollo", () => {
       test("recoveryId secp256k1+priv - matches - returns Secp256k1PrivateKey instance", () => {
         const key: StorableKey = {
           recoveryId: StorableKey.recoveryId("secp256k1", "priv"),
-          raw: Fixtures.Keys.secp256K1.privateKey.raw
+          data: getStorableData(Fixtures.Keys.secp256K1.privateKey)
         };
 
         const result = apollo.restorePrivateKey(key);
@@ -440,7 +451,7 @@ describe("Apollo", () => {
       test("recoveryId ed25519+pub - matches - returns Ed25519PrivateKey instance", () => {
         const key: StorableKey = {
           recoveryId: StorableKey.recoveryId("ed25519", "pub"),
-          raw: Fixtures.Keys.ed25519.publicKey.raw
+          data: getStorableData(Fixtures.Keys.ed25519.publicKey)
         };
 
         const result = apollo.restorePublicKey(key);
@@ -451,7 +462,7 @@ describe("Apollo", () => {
       test("recoveryId x25519+pub - matches - returns X25519PublicKey instance", () => {
         const key: StorableKey = {
           recoveryId: StorableKey.recoveryId("x25519", "pub"),
-          raw: Fixtures.Keys.x25519.publicKey.raw
+          data: getStorableData(Fixtures.Keys.x25519.publicKey)
         };
 
         const result = apollo.restorePublicKey(key);
@@ -462,7 +473,7 @@ describe("Apollo", () => {
       test("recoveryId secp256k1+pub - matches - returns Secp256k1PublicKey instance", () => {
         const key: StorableKey = {
           recoveryId: StorableKey.recoveryId("secp256k1", "pub"),
-          raw: Fixtures.Keys.secp256K1.publicKey.raw
+          data: getStorableData(Fixtures.Keys.secp256K1.publicKey)
         };
 
         const result = apollo.restorePublicKey(key);

--- a/packages/lib/sdk/tests/apollo/keys/Secp256k1.test.ts
+++ b/packages/lib/sdk/tests/apollo/keys/Secp256k1.test.ts
@@ -64,7 +64,7 @@ describe("Keys", () => {
           expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
 
           // expect(result.getProperty(KeyProperties.derivationPath)).to.eq(derivationPath.toString());
-          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f30272f30272f3027");
+          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/0'/0'/0'");
         });
 
         test("DerivationPath - m/1'/0'/0'", () => {
@@ -79,7 +79,7 @@ describe("Keys", () => {
           expect(result.getProperty(KeyProperties.chainCode)).to.eq("f22fdc4dd573ce17243983faa6492fc33fab35ecfa3f8ad09aa958044a2752f7");
           expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
           // expect(result.getProperty(KeyProperties.derivationPath)).to.eq(`m/1'/0'/0'`);
-          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f31272f30272f3027");
+          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/1'/0'/0'");
         });
 
         test("DerivationPath - m/2'/0'/0'", () => {
@@ -93,7 +93,7 @@ describe("Keys", () => {
           expect(result.getProperty(KeyProperties.chainCode)).to.eq("e56cd109bae854dcf3fc0b766067f9e825901bf1bcfc67dc4f5eaee74cf9c8ea");
           expect(result.getProperty(KeyProperties.index)).to.eq(`${derivationPath.index}`);
           // expect(result.getProperty(KeyProperties.derivationPath)).to.eq(`m/1'/0'/0'`);
-          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("6d2f32272f30272f3027");
+          expect(result.getProperty(KeyProperties.derivationPath)).to.eq("m/2'/0'/0'");
         });
 
         test("Secp.derive returns same as HDKey.derive", () => {

--- a/packages/lib/sdk/tests/mercury/Mercury.test.ts
+++ b/packages/lib/sdk/tests/mercury/Mercury.test.ts
@@ -77,7 +77,6 @@ describe("Mercury", () => {
       fromDID = DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
       toDID = DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
 
-      vi.spyOn(castor, "parseDID").mockReturnValue(fromDID);
       vi.spyOn(httpManager, "request").mockResolvedValue(new Domain.ApiResponse<any>({}, 200));
     });
 


### PR DESCRIPTION
### Description
Previously the derivationPath was being stored in the Private and Public key properties encoded as a hex string.


### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
