### PR TITLE
fix: export the default did methods

### DIFF
--- a/packages/lib/sdk/src/castor/index.ts
+++ b/packages/lib/sdk/src/castor/index.ts
@@ -14,7 +14,7 @@ import { type PrismDIDMethod, type PeerDIDMethod } from "./methods";
 import { type DIDMethodInput } from "./types";
 import { parseParams } from "./utils";
 
-export type * from "./methods";
+export * from "./methods";
 
 /**
  * All DID methods available on a Castor instance -- the built-in


### PR DESCRIPTION

### Description
Just adding a missing export for the did methods so we can use them in e2e tests

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
