### PR TITLE
fix: making mercury did agnostic and support prism didcomm messages

### DIFF
--- a/packages/lib/sdk/src/edge-agent/didFunctions/CreatePrismDID.ts
+++ b/packages/lib/sdk/src/edge-agent/didFunctions/CreatePrismDID.ts
@@ -29,7 +29,6 @@ export class CreatePrismDID extends Task<Domain.DID, Args> {
   async run(ctx: AgentContext) {
     const index = await ctx.run(new PrismKeyPathIndexTask({ index: this.args.keyPathIndex }));
     const masterKeyDerivation = PrismDerivationPath.init(index, PrismDIDKeyUsage.MASTER_KEY);
-    // TODO should this be using AUTHENTICATION_KEY
     const issuingDerivation = PrismDerivationPath.init(index, PrismDIDKeyUsage.ISSUING_KEY);
 
     const seed = new Uint8Array(await ctx.Seed());

--- a/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
@@ -22,7 +22,6 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
   async resolve(did: string): Promise<DIDComm.DIDDoc | null> {
     const { DIDDocument, CastorError, Curve, expect } = await import("@hyperledger/identus-domain");
     const doc = await this.castor.resolveDID(did);
-
     const authentications: string[] = [];
     const keyAgreements: string[] = [];
     const services: DIDComm.Service[] = [];
@@ -58,10 +57,7 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
         });
       }
 
-      if (
-        coreProperty instanceof DIDDocument.Service &&
-        coreProperty.type.includes(DIDCommMessagingKey)
-      ) {
+      if (coreProperty instanceof DIDDocument.Service) {
         services.push({
           id: coreProperty.id,
           type: DIDCommMessagingKey,

--- a/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
@@ -44,13 +44,10 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
 
 
   async find_secrets(secret_ids: string[]): Promise<string[]> {
-    const peerDids = await this.pluto.getAllPeerDIDs();
     const results = await Promise.all(
       secret_ids.map(async (secretId) => {
         const secretDID = await this.parseDIDUrl(secretId);
-        const found = peerDids.find((peerDIDSecret: any) => {
-          return secretDID.did.toString() === peerDIDSecret.did.toString();
-        });
+        const found = await this.pluto.getDIDByDIDOrAlias(secretDID.did.toString());
         return found ? secretId : null;
       })
     );
@@ -59,14 +56,10 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
 
   async get_secret(secret_id: string): Promise<DIDComm.Secret | null> {
     const { DIDDocument } = await import("@hyperledger/identus-domain");
-    const peerDids = await this.pluto.getAllPeerDIDs();
     const secretDID = await this.parseDIDUrl(secret_id);
-    const found = peerDids.find((peerDIDSecret: any) => {
-      return secretDID.did.toString() === peerDIDSecret.did.toString();
-    });
+    const found = await this.pluto.getDIDByDIDOrAlias(secretDID.did.toString());
     if (found) {
-      const did = await this.castor.resolveDID(found.did.toString());
-
+      const did = await this.castor.resolveDID(found.toString());
       const [publicKeyJWK] = did.coreProperties.reduce<import("@hyperledger/identus-domain").JWK[]>((all, property) => {
         if (property instanceof DIDDocument.VerificationMethods) {
           const matchingValue =
@@ -90,12 +83,13 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
   }
 
   private async mapToSecret(
-    peerDid: import("@hyperledger/identus-domain").PeerDID,
+    did: import("@hyperledger/identus-domain").DID,
     publicKeyJWK: import("@hyperledger/identus-domain").JWK
   ): Promise<DIDComm.Secret> {
     const { Curve, KeyTypes } = await import("@hyperledger/identus-domain");
-    const privateKeyBuffer = peerDid.privateKeys.find(
-      (key) => key.keyCurve.curve === Curve.X25519
+    const privateKeys = await this.pluto.getDIDPrivateKeysByDID(did);
+    const privateKeyBuffer = privateKeys.find(
+      (key) => key.curve.toString() === Curve.X25519.toString()
     );
     if (!privateKeyBuffer) {
       throw new Error(`Invalid PrivateKey Curve ${Curve.X25519}`);
@@ -108,8 +102,7 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
     const ecnumbasis = await computeEncnumbasis(
       privateKey.publicKey()
     );
-    const id = `${peerDid.did.toString()}#${ecnumbasis}`;
-
+    const id = `${did.toString()}#${ecnumbasis}`;
     const secret: DIDComm.Secret = {
       id,
       type: "JsonWebKey2020",

--- a/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
+++ b/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
@@ -4,7 +4,6 @@ import { Castor } from "../../../src/castor";
 import { Pluto } from "../../../src/pluto/Pluto";
 import * as Domain from "@hyperledger/identus-domain";
 import { DIDCommSecretsResolver } from "../../../src/mercury/DIDCommSecretsResolver";
-import { PeerDIDCreate } from "../../../src/castor/methods/peer/PeerDIDCreate";
 import { Curve } from "@hyperledger/identus-domain";
 import * as Fixtures from "../../fixtures";
 import * as utils from '../../../src/castor/utils';
@@ -25,7 +24,8 @@ describe("Mercury DIDComm SecretsResolver", () => {
     } as any;
 
     pluto = {
-      getAllPeerDIDs: async () => [],
+      getDIDByDIDOrAlias: async () => null,
+      getDIDPrivateKeysByDID: async () => [],
     } as any;
 
     secretsResolver = new DIDCommSecretsResolver(apollo, castor, pluto);
@@ -40,7 +40,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
       const did = Domain.DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
       const secret = did.toString();
       // TODO: update when PeerDID Types are fixed
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([{ did: secret } as any]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(Domain.DID.fromString(secret));
 
       const result = await secretsResolver.find_secrets([secret]);
 
@@ -48,21 +48,32 @@ describe("Mercury DIDComm SecretsResolver", () => {
       expect(result).to.contain(secret);
     });
 
-    it("should return matched secret - no duplicates", async () => {
+    it("should return matched secret also if missing duplicates exist", async () => {
       const did = Domain.DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
       const secret = did.toString();
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([{ did: secret }, { did: secret }] as any);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(Domain.DID.fromString(secret));
+
+      const result = await secretsResolver.find_secrets([secret, secret]);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result).to.eql([secret, secret]);
+    });
+
+    it("should return matched secret for PRISM DID", async () => {
+      const did = Domain.DID.fromString("did:prism:4a5b2cb64f8faa318545eac4869c4f7b600f681a938cde99320aeeb6af1bd770");
+      const secret = did.toString();
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(Domain.DID.fromString(secret));
 
       const result = await secretsResolver.find_secrets([secret]);
 
       expect(result).to.have.lengthOf(1);
-      expect(result).to.eql([secret]);
+      expect(result).to.contain(secret);
     });
 
     it("should return empty array with unmatched secret", async () => {
       const did = Domain.DID.fromString("did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ");
       const secret = did.toString();
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(null);
 
       const result = await secretsResolver.find_secrets([secret]);
 
@@ -82,20 +93,15 @@ describe("Mercury DIDComm SecretsResolver", () => {
       };
       const ecnum = "ecnum123";
       const privateKey = Fixtures.Keys.x25519.privateKey;
-      const peerDid = {
-        did: secret,
-        curve: Curve.X25519,
-        privateKeys: [
-          {
-            keyCurve: {
-              curve: privateKey.curve
-            },
-            value: privateKey.getEncoded(),
-          },
-        ],
-      } as any;
+      const privateKeys = [
+        {
+          curve: Curve.X25519,
+          value: privateKey.getEncoded(),
+        },
+      ];
 
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([peerDid]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did as any);
+      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys as any);
       vi.spyOn(castor, "resolveDID").mockResolvedValue(
         new Domain.DIDDocument(did, [
           new Domain.DIDDocument.VerificationMethods([
@@ -119,9 +125,61 @@ describe("Mercury DIDComm SecretsResolver", () => {
         id: `${secret}#${ecnum}`,
         type: "JsonWebKey2020",
         privateKeyJwk: {
-          crv: peerDid.curve,
+          crv: Curve.X25519,
           kty: "OKP",
-          d: peerDid.privateKeys[0].value.toString(),
+          d: privateKeys[0].value.toString(),
+          x: publicKeyJwk.x as any,
+        },
+      });
+    });
+
+    it("should return matched secret for PRISM DID", async () => {
+      const did = Domain.DID.fromString("did:prism:4a5b2cb64f8faa318545eac4869c4f7b600f681a938cde99320aeeb6af1bd770");
+      const secret = did.toString();
+      const publicKeyJwk: Domain.JWK.OKP = {
+        crv: Domain.Curve.X25519,
+        kid: "kid",
+        kty: "OKP",
+        x: Buffer.from(new Uint8Array()).toString("base64url"),
+      };
+      const ecnum = "ecnum123";
+      const privateKey = Fixtures.Keys.x25519.privateKey;
+
+      const privateKeys = [
+        {
+          curve: Curve.X25519,
+          value: privateKey.getEncoded(),
+        },
+      ];
+
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did as any);
+      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys as any);
+      vi.spyOn(castor, "resolveDID").mockResolvedValue(
+        new Domain.DIDDocument(did, [
+          new Domain.DIDDocument.VerificationMethods([
+            new Domain.DIDDocument.VerificationMethod(
+              secret,
+              "controller",
+              "JsonWebKey2020",
+              publicKeyJwk
+            ),
+          ]),
+        ])
+      );
+
+      vi.spyOn(utils, "computeEncnumbasis").mockReturnValue(Promise.resolve(ecnum));
+      vi.spyOn(apollo, "createPrivateKey").mockReturnValue(privateKey);
+
+      const result = await secretsResolver.get_secret(secret);
+
+      expect(result).not.to.be.null;
+      expect(result).to.eql({
+        id: `${secret}#${ecnum}`,
+        type: "JsonWebKey2020",
+        privateKeyJwk: {
+          crv: Curve.X25519,
+          kty: "OKP",
+          d: privateKeys[0].value.toString(),
           x: publicKeyJwk.x as any,
         },
       });
@@ -132,7 +190,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
         "did:peer:2.Ez6LSms555YhFthn1WV8ciDBpZm86hK9tp83WojJUmxPGk1hZ.Vz6MkmdBjMyB4TS5UbbQw54szm8yvMMf1ftGV2sQVYAxaeWhE.SeyJpZCI6Im5ldy1pZCIsInQiOiJkbSIsInMiOnsidXJpIjoiaHR0cHM6Ly9tZWRpYXRvci5yb290c2lkLmNsb3VkIiwiYSI6WyJkaWRjb21tL3YyIl19fQ"
       );
       const secret = did.toString();
-      vi.spyOn(pluto, "getAllPeerDIDs").mockResolvedValue([]);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(null);
 
       const result = await secretsResolver.get_secret(secret);
 


### PR DESCRIPTION
### Description

Allows us to resolve prism:dids in mercury, it is a partial implementation of prism:did support for DIDComm.
In this phase, we are able to parse and resolve prism:dids as to fields in DIDComm messages.

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
