### PR TITLE
test: add connectionless issuance e2e tests

### DIFF
--- a/integration-tests/e2e-tests/features/connectionless_issuance.feature
+++ b/integration-tests/e2e-tests/features/connectionless_issuance.feature
@@ -1,0 +1,26 @@
+@jwt @connectionless @issuance
+Feature: JWT Connectionless issuance
+  The Edge Agent should receive a connectionless jwt credential
+
+  Scenario: Successful issuance without DID connection
+    Given Cloud Agent is not connected to Edge Agent
+    And Cloud Agent uses did='secp256k1' and kid='assert1' for issuance
+    And Cloud Agent uses jwt schema issued with did='secp256k1'
+    When Cloud Agent has a connectionless jwt credential offer invitation
+    And Cloud Agent shares invitation to Edge Agent
+    And Edge Agent connects through the invite
+    Then Edge Agent should receive the credentials offer from Cloud Agent
+    When Edge Agent accepts the credentials offer from Cloud Agent
+    Then Edge Agent wait to receive issued credentials from Cloud Agent
+    And Edge Agent process issued credentials from Cloud Agent
+    And no DID connection should be created for Edge Agent
+    And the credential should be stored in Edge Agent
+    And Cloud Agent is not connected to Edge Agent
+
+  Scenario: Tampered offer should fail
+    Given an invalid connectionless offer invitation for Edge Agent
+    Then invalid issuance error should be thrown for Edge Agent
+
+  Scenario: Corrupt attachment should fail
+    Given a corrupt OOB invitation for Edge Agent
+    Then corrupt attachment error should be thrown for Edge Agent

--- a/integration-tests/e2e-tests/src/steps/connectionless-issuance.steps.ts
+++ b/integration-tests/e2e-tests/src/steps/connectionless-issuance.steps.ts
@@ -1,0 +1,52 @@
+import { Given, Then } from "@cucumber/cucumber"
+import { type Actor, notes } from "@serenity-js/core"
+import { EdgeAgentWorkflow } from "../workflow/EdgeAgentWorkflow"
+import { WalletSdk } from "../abilities/WalletSdk"
+import { assert } from "chai"
+
+Then("no DID connection should be created for {actor}", async function (edgeAgent: Actor) {
+  await edgeAgent.attemptsTo(
+    WalletSdk.execute(async (sdk) => {
+      const didPairs = await sdk.pluto.getAllDidPairs()
+      assert.equal(didPairs.length, 0, "DID connection should not be created for connectionless issuance")
+    })
+  )
+})
+
+Then("the credential should be stored in {actor}", async function (edgeAgent: Actor) {
+  await edgeAgent.attemptsTo(
+    WalletSdk.execute(async (sdk) => {
+      const credentials = await sdk.verifiableCredentials()
+      assert.isAbove(credentials.length, 0, "Credential should be stored")
+    })
+  )
+})
+
+Given("an invalid connectionless offer invitation for {actor}", async function (edgeAgent: Actor) {
+  const tamperedInvitation = "https://example.com?_oob=eyJpZCI6ImVycW9vYmkiLCJ0eXBlIjoiaHR0cHM6Ly9kaWRjb21tLm9yZy9vdXQtb2YtYmFuZC8yLjAvaW52aXRhdGlvbiIsImZyb20iOiJkaWQ6ZXhhbXBsZToxMjMiLCJib2R5Ijp7fSwiYXR0YWNobWVudHMiOltdfQ"
+  await edgeAgent.attemptsTo(notes().set("invitation", tamperedInvitation))
+})
+
+Given("a corrupt OOB invitation for {actor}", async function (edgeAgent: Actor) {
+  await edgeAgent.attemptsTo(notes().set("invitation", "not-a-url"))
+})
+
+Then("invalid issuance error should be thrown for {actor}", async function (edgeAgent: Actor) {
+  try {
+    await EdgeAgentWorkflow.connect(edgeAgent)
+    await EdgeAgentWorkflow.waitForCredentialOffer(edgeAgent, 1)
+    await EdgeAgentWorkflow.acceptCredential(edgeAgent)
+    assert.fail("Should have failed")
+  } catch (e: any) {
+    assert.isDefined(e)
+  }
+})
+
+Then("corrupt attachment error should be thrown for {actor}", async function (edgeAgent: Actor) {
+  try {
+    await EdgeAgentWorkflow.connect(edgeAgent)
+    assert.fail("Should have failed")
+  } catch (e: any) {
+    assert.isDefined(e)
+  }
+})


### PR DESCRIPTION
This PR adds end-to-end tests for the connectionless credential issuance flow.

The goal is to cover how a credential offer is handled when shared via an Out-of-Band (OOB) invitation, without requiring a prior DID connection between the issuer and holder.

What’s included

1. A successful connectionless issuance scenario using an OOB invitation
2. A check to ensure no DID connection is created during the flow
3. Validation that the issued credential is stored correctly
4. A couple of failure scenarios for invalid or malformed invitations

Implementation details

The tests follow the existing Cucumber + Screenplay pattern used in the repository and reuse the current Cloud Agent and Edge Agent workflows. No new patterns or helpers were introduced — everything is kept consistent with the existing E2E setup.

Note

Running these tests locally may require a Unix-like environment (e.g. WSL, macOS, or Linux) due to native build steps in the SDK.

Ref: hyperledger-identus/integration#2
