### PR TITLE
test: add connectionless presentation e2e tests

### DIFF
--- a/integration-tests/e2e-tests/features/connectionless_presentation.feature
+++ b/integration-tests/e2e-tests/features/connectionless_presentation.feature
@@ -1,0 +1,23 @@
+@jwt @connectionless @proof
+Feature: JWT Connectionless presentation
+  The Edge Agent should provide a connectionless proof
+
+  Scenario: Successful connectionless presentation without DID connection
+    Given Cloud Agent is not connected to Edge Agent
+    And Cloud Agent uses did='secp256k1' and kid='assert1' for issuance
+    When Cloud Agent has a connectionless jwt verification invite
+    And Cloud Agent shares invitation to Edge Agent
+    And Edge Agent connects through the invite
+    And Edge Agent sends the present-proof
+    Then Cloud Agent should see the present-proof is verified
+    And no DID connection should be created for Edge Agent
+
+  Scenario: Tampered presentation request should fail
+    Given an invalid connectionless presentation request for Edge Agent
+    When Edge Agent connects through the invite
+    Then invalid verification error should be thrown for Edge Agent
+
+  Scenario: Missing credentials should fail
+    Given a presentation request for unsupported credential type for Edge Agent
+    When Edge Agent connects through the invite
+    Then an error should be thrown for Edge Agent

--- a/integration-tests/e2e-tests/src/steps/connectionless-presentation.steps.ts
+++ b/integration-tests/e2e-tests/src/steps/connectionless-presentation.steps.ts
@@ -1,0 +1,43 @@
+import { Given, Then } from "@cucumber/cucumber"
+import { type Actor, notes } from "@serenity-js/core"
+import { EdgeAgentWorkflow } from "../workflow/EdgeAgentWorkflow"
+import { WalletSdk } from "../abilities/WalletSdk"
+import { assert } from "chai"
+
+Then("no DID connection should be created for {actor}", async function (edgeAgent: Actor) {
+  await edgeAgent.attemptsTo(
+    WalletSdk.execute(async (sdk) => {
+      const didPairs = await sdk.pluto.getAllDidPairs()
+      assert.equal(didPairs.length, 0, "DID connection should not be created for connectionless presentation")
+    })
+  )
+})
+
+Given("an invalid connectionless presentation request for {actor}", async function (edgeAgent: Actor) {
+  const tamperedInvitation = "https://example.com?_oob=eyJ0eXBlIjoiaHR0cHM6Ly9kaWRjb21tLm9yZy9vdXQtb2YtYmFuZC8yLjAvaW52aXRhdGlvbiIsImlkIjoiMTIzIiwiaW52aXRlcCI6InRhbXBlcmVkIn0="
+  await edgeAgent.attemptsTo(notes().set("invitation", tamperedInvitation))
+})
+
+Then("invalid verification error should be thrown for {actor}", async function (edgeAgent: Actor) {
+  try {
+    await EdgeAgentWorkflow.waitForProofRequest(edgeAgent)
+    await EdgeAgentWorkflow.presentProof(edgeAgent)
+    assert.fail("Should have failed with invalid invitation")
+  } catch (e: any) {
+    assert.isDefined(e)
+  }
+})
+
+Given("a presentation request for unsupported credential type for {actor}", async function (edgeAgent: Actor) {
+  // We can simulate this by setting a presentationId or invitation that refers to something the agent doesn't have
+  await edgeAgent.attemptsTo(notes().set("presentationId", "non-existent-id"))
+})
+
+Then("an error should be thrown for {actor}", async function (edgeAgent: Actor) {
+  try {
+    await EdgeAgentWorkflow.presentProof(edgeAgent)
+    assert.fail("Should have thrown an error")
+  } catch (e: any) {
+    assert.isDefined(e, "Error should have been thrown")
+  }
+})


### PR DESCRIPTION
This PR adds Cucumber-based E2E test coverage for the connectionless presentation flow.

The tests validate how presentation requests are handled when shared via an Out-of-Band (OOB) invitation, without requiring a prior DID connection between the verifier and holder.

What’s included

1. Successful connectionless presentation scenario using an OOB invitation
2. Validation that no DID connection is created during the flow
3. Verification that the presentation is correctly processed
4. Failure scenarios for tampered requests and unsupported credential types 

Implementation details

The implementation follows the existing Cucumber + Screenplay pattern and reuses the current Cloud Agent and Edge Agent workflows. Only minimal logic was added for connectionless-specific assertions.

Notes

Running these tests locally may require a Unix-like environment (e.g. WSL, macOS, or Linux) due to native build steps used in the SDK.

Ref: hyperledger-identus/integration#3
