### PR TITLE
fix(mercury): correct JWK encoding in DIDComm bridge

### DIFF
--- a/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
@@ -43,6 +43,7 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
           }
           const publicKeyBase64 = method.publicKeyJwk?.x as any;
           const publicKeyKid = (method.publicKeyJwk as any).kid;
+          const kty = (curve === Curve.ED25519 || curve === Curve.X25519) ? "OKP" : "EC";
           verificationMethods.push({
             controller: method.controller,
             id: method.id,
@@ -50,7 +51,7 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
             publicKeyJwk: {
               crv: method.publicKeyJwk?.crv,
               kid: publicKeyKid,
-              kty: "OKP",
+              kty,
               x: publicKeyBase64,
             },
           });

--- a/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import type * as DIDComm from "@hyperledger/identus-didcomm";
+import { base64url } from "multiformats/bases/base64";
 import { computeEncnumbasis } from "../castor/utils";
 
 /**
@@ -109,7 +110,7 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
       privateKeyJwk: {
         crv: Curve.X25519,
         kty: "OKP",
-        d: Buffer.from(privateKey.getEncoded()).toString(),
+        d: base64url.baseEncode(privateKey.raw),
         x: publicKeyJWK.x,
       },
     };

--- a/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommSecretsResolver.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import type * as DIDComm from "@hyperledger/identus-didcomm";
-import { base64url } from "multiformats/bases/base64";
 import { computeEncnumbasis } from "../castor/utils";
 
 /**
@@ -61,23 +60,13 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
     const found = await this.pluto.getDIDByDIDOrAlias(secretDID.did.toString());
     if (found) {
       const did = await this.castor.resolveDID(found.toString());
-      const [publicKeyJWK] = did.coreProperties.reduce<import("@hyperledger/identus-domain").JWK[]>((all, property) => {
-        if (property instanceof DIDDocument.VerificationMethods) {
-          const matchingValue =
-            property.values.find(
-              (verificationMethod) => verificationMethod.id === secret_id
-            );
+      const hasMatchingMethod = did.coreProperties.some((property) =>
+        property instanceof DIDDocument.VerificationMethods &&
+        property.values.some((vm) => vm.id === secret_id && vm.publicKeyJwk)
+      );
 
-          if (matchingValue && matchingValue.publicKeyJwk) {
-            return [...all, matchingValue.publicKeyJwk];
-          }
-        }
-        return all;
-      }, []);
-
-      if (publicKeyJWK) {
-        const secret = await this.mapToSecret(found, publicKeyJWK);
-        return secret;
+      if (hasMatchingMethod) {
+        return this.mapToSecret(found);
       }
     }
     return null;
@@ -85,7 +74,6 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
 
   private async mapToSecret(
     did: import("@hyperledger/identus-domain").DID,
-    publicKeyJWK: import("@hyperledger/identus-domain").JWK
   ): Promise<DIDComm.Secret> {
     const { Curve, KeyTypes } = await import("@hyperledger/identus-domain");
     const privateKeys = await this.pluto.getDIDPrivateKeysByDID(did);
@@ -100,21 +88,15 @@ export class DIDCommSecretsResolver implements DIDComm.SecretsResolver {
       curve: Curve.X25519,
       raw: privateKeyBuffer.value,
     });
-    const ecnumbasis = await computeEncnumbasis(
-      privateKey.publicKey()
-    );
+    if (!privateKey.isExportable()) {
+      throw new Error("PrivateKey is not exportable");
+    }
+    const ecnumbasis = await computeEncnumbasis(privateKey.publicKey());
     const id = `${did.toString()}#${ecnumbasis}`;
-    const secret: DIDComm.Secret = {
+    return {
       id,
       type: "JsonWebKey2020",
-      privateKeyJwk: {
-        crv: Curve.X25519,
-        kty: "OKP",
-        d: base64url.baseEncode(privateKey.raw),
-        x: publicKeyJWK.x,
-      },
+      privateKeyJwk: privateKey.to.JWK(),
     };
-
-    return secret;
   }
 }

--- a/packages/lib/sdk/tests/mercury/didcomm/DIDResolver.test.ts
+++ b/packages/lib/sdk/tests/mercury/didcomm/DIDResolver.test.ts
@@ -81,7 +81,7 @@ describe("Mercury DIDComm DIDResolver", () => {
           publicKeyJwk: {
             crv: vmOther.publicKeyJwk?.crv,
             kid: (vmOther.publicKeyJwk as any)?.kid,
-            kty: "OKP",
+            kty: "EC",
             x: vmOther.publicKeyJwk?.x as any,
           },
         },

--- a/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
+++ b/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
@@ -5,7 +5,6 @@ import { Pluto } from "../../../src/pluto/Pluto";
 import * as Domain from "@hyperledger/identus-domain";
 import { DIDCommSecretsResolver } from "../../../src/mercury/DIDCommSecretsResolver";
 import { Curve } from "@hyperledger/identus-domain";
-import { base64url } from "multiformats/bases/base64";
 import * as Fixtures from "../../fixtures";
 import * as utils from '../../../src/castor/utils';
 
@@ -125,12 +124,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
       expect(result).to.eql({
         id: `${secret}#${ecnum}`,
         type: "JsonWebKey2020",
-        privateKeyJwk: {
-          crv: Curve.X25519,
-          kty: "OKP",
-          d: base64url.baseEncode(privateKey.raw),
-          x: publicKeyJwk.x as any,
-        },
+        privateKeyJwk: privateKey.to.JWK(),
       });
     });
 
@@ -177,12 +171,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
       expect(result).to.eql({
         id: `${secret}#${ecnum}`,
         type: "JsonWebKey2020",
-        privateKeyJwk: {
-          crv: Curve.X25519,
-          kty: "OKP",
-          d: base64url.baseEncode(privateKey.raw),
-          x: publicKeyJwk.x as any,
-        },
+        privateKeyJwk: privateKey.to.JWK(),
       });
     });
 

--- a/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
+++ b/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
@@ -5,6 +5,7 @@ import { Pluto } from "../../../src/pluto/Pluto";
 import * as Domain from "@hyperledger/identus-domain";
 import { DIDCommSecretsResolver } from "../../../src/mercury/DIDCommSecretsResolver";
 import { Curve } from "@hyperledger/identus-domain";
+import { base64url } from "multiformats/bases/base64";
 import * as Fixtures from "../../fixtures";
 import * as utils from '../../../src/castor/utils';
 
@@ -127,7 +128,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
         privateKeyJwk: {
           crv: Curve.X25519,
           kty: "OKP",
-          d: privateKeys[0].value.toString(),
+          d: base64url.baseEncode(privateKey.raw),
           x: publicKeyJwk.x as any,
         },
       });
@@ -179,7 +180,7 @@ describe("Mercury DIDComm SecretsResolver", () => {
         privateKeyJwk: {
           crv: Curve.X25519,
           kty: "OKP",
-          d: privateKeys[0].value.toString(),
+          d: base64url.baseEncode(privateKey.raw),
           x: publicKeyJwk.x as any,
         },
       });


### PR DESCRIPTION
### Description

Two spec violations in the DIDComm bridge:

1. ```DIDCommSecretsResolver``` encodes the JWK ```d``` parameter using ```Buffer.from(...).toString()``` (UTF-8), but RFC 8037 §2 requires base64url. The SDK already does this correctly for ```x``` in ```JWKHelper.toJWK``` ,the ```d``` side just never matched.

2. ```DIDCommDIDResolver``` hardcodes ```kty: "OKP"``` for all verification methods. RFC 7518 §6.1 requires ```"EC"``` for secp256k1 curves.

The existing tests asserted the buggy output rather than the spec , so fixed those too.

### Alternatives Considered (optional)

Used ```privateKey.raw``` over ```privateKey.getEncoded()``` since ```raw``` is what ```JWKHelper.toJWK``` uses for ```x```, and ```getEncoded()``` round-trips through WASM unnecessarily.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)