### PR TITLE
fix(sdjwt): remove console.log from verify error handling

### DIFF
--- a/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
@@ -91,9 +91,8 @@ export class SDJWT extends Task.Runner {
             options.requiredKeyBindings ?? false
           );
           return true;
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.log(err);
+        } catch {
+          // Continue to next verification method
         }
       }
     }


### PR DESCRIPTION
Fixes #553

Replaces console.log with silent error handling to prevent leaking error details to stdout in production.

**Changes:**
- Removed console.log(err) from SDJWT.verify() error handler
- Added descriptive comment about continuing to next verification method
- Matches the error handling pattern used in JWT.verify()

**Why:** Error logging in the browser console exposes sensitive error details in production environments. Silent error handling is appropriate here since we're iterating through multiple verification methods.