### PR TITLE
fix(castor): verify long-form PRISM DID state hash

### DIFF
--- a/packages/lib/sdk/src/castor/index.ts
+++ b/packages/lib/sdk/src/castor/index.ts
@@ -143,12 +143,18 @@ export class Castor<
   async resolveDID(didstr: Domain.DID | string): Promise<DIDDocument> {
     const did = Domain.DID.from(didstr);
     const resolvers = this.#resolvers.filter(x => x.method === did.method);
+    let lastError:unknown;
+
     for (const resolver of resolvers) {
       try {
         return await resolver.resolve(did.toString());
-      } catch {
+      } catch (error) {
+        lastError = error;
         console.log(`Failed resolving did ${did.toString()}`);
       }
+    }
+    if(lastError instanceof Error){
+      throw lastError;
     }
     throw new Error(`Non of the available Castor resolvers could resolve the DID '${didstr.toString()}'`);
   }

--- a/packages/lib/sdk/src/castor/index.ts
+++ b/packages/lib/sdk/src/castor/index.ts
@@ -1,5 +1,5 @@
 import * as Domain from '@hyperledger/identus-domain';
-import { type DIDDocument } from "@hyperledger/identus-domain";
+import { type DIDDocument, CastorError } from "@hyperledger/identus-domain";
 
 import {
   type CreatePayloadOf,
@@ -143,7 +143,7 @@ export class Castor<
   async resolveDID(didstr: Domain.DID | string): Promise<DIDDocument> {
     const did = Domain.DID.from(didstr);
     const resolvers = this.#resolvers.filter(x => x.method === did.method);
-    let lastError:unknown;
+    let lastError: unknown;
 
     for (const resolver of resolvers) {
       try {
@@ -153,7 +153,7 @@ export class Castor<
         console.log(`Failed resolving did ${did.toString()}`);
       }
     }
-    if(lastError instanceof Error){
+    if (lastError instanceof CastorError.InitialStateOfDIDChanged) {
       throw lastError;
     }
     throw new Error(`Non of the available Castor resolvers could resolve the DID '${didstr.toString()}'`);

--- a/packages/lib/sdk/src/castor/resolver/LongFormPrismDIDResolver.ts
+++ b/packages/lib/sdk/src/castor/resolver/LongFormPrismDIDResolver.ts
@@ -30,7 +30,7 @@ export class LongFormPrismDIDResolver implements DIDResolver {
     const prismDID = new LongFormPrismDID(did);
     const state = prismDID.encodedState;
     const base64State = base64.base64url.decode(`u${state}`);
-    const coreProperties = this.decodeState(did, base64State);
+    const coreProperties = this.decodeState(did, prismDID.stateHash, base64State);
     return new DIDDocument(did, coreProperties);
   }
 
@@ -38,15 +38,12 @@ export class LongFormPrismDIDResolver implements DIDResolver {
     return proto.compressed_ec_key_data?.curve ?? proto.ec_key_data.curve;
   }
 
-  private decodeState(did: DID, encodedData: Uint8Array): DIDDocument.CoreProperty[] {
+  private decodeState(did: DID, stateHash: string, encodedData: Uint8Array): DIDDocument.CoreProperty[] {
     try {
       const verifyEncodedState = new SHA256().update(encodedData).digest();
-      const verifyEncodedStateHex = verifyEncodedState;
+      const verifyEncodedStateHex = Buffer.from(verifyEncodedState).toString("hex");
 
-      if (
-        Buffer.from(verifyEncodedState).toString("hex") !==
-        Buffer.from(verifyEncodedStateHex).toString("hex")
-      ) {
+      if (verifyEncodedStateHex !== stateHash) {
         throw new CastorError.InitialStateOfDIDChanged();
       }
 

--- a/packages/lib/sdk/tests/castor/PrismDID.test.ts
+++ b/packages/lib/sdk/tests/castor/PrismDID.test.ts
@@ -7,6 +7,7 @@ import * as Fixtures from "../fixtures";
 import * as Protos from "@hyperledger/identus-protos";
 import { ed25519, x25519 } from "../fixtures/keys";
 import {
+  CastorError,
   Curve,
   DID,
   DIDDocument,
@@ -120,6 +121,18 @@ describe("PrismDID",
           expect(cp1vm0?.publicKeyJwk).toBeUndefined();
           expect(cp1vm0?.publicKeyMultibase).toEqual("zSXxpYB6edvxvWxRTo3kMUoTTQVHpbNnXo2Z1AjLA78iqLdK2kVo5xw9rGg8uoEgmhxYahNur3RvV7HnaktWBqkXt");
           expect(cp1vm0?.type).toEqual("EcdsaSecp256k1VerificationKey2019");
+        });
+
+        test("throws when long-form DID state hash does not match encoded state", async () => {
+          const didStr = "did:prism:032e7383265cab026f4bdf8b903f8f78840fefc5b201ccce06fc263f7b3be5df:CskBCsYBEl0KCG1hc3Rlci0wEAFCTwoJc2VjcDI1NmsxEiD9IDIUwFTpO0oFkZbs5niSI7ZtvmDHOgG6w93jyiUI_hog2ZbGuaULlxsyr4CtdA_Es7g74e_buaDAe_mXiTQIfosSZQoQYXV0aGVudGljYXRpb24tMBAEQk8KCXNlY3AyNTZrMRIg_SAyFMBU6TtKBZGW7OZ4kiO2bb5gxzoBusPd48olCP4aINmWxrmlC5cbMq-ArXQPxLO4O-Hv27mgwHv5l4k0CH6L";
+          const tamperedDid = didStr.replace(
+            "032e7383265cab026f4bdf8b903f8f78840fefc5b201ccce06fc263f7b3be5df",
+            "0000000000000000000000000000000000000000000000000000000000000000"
+          );
+
+          await expect(castor.resolveDID(tamperedDid)).rejects.toThrow(
+            CastorError.InitialStateOfDIDChanged
+          );
         });
 
         const masterKeyId = `master-0`;


### PR DESCRIPTION
### Description

Fixes #579

`LongFormPrismDIDResolver` was computing SHA256 of the encoded state but comparing it against itself, making the integrity check a no-op. A tampered long-form DID would always resolve without error.

Fixed the comparison to check `SHA256(base64url_decode(encodedState))` against the state hash embedded in the DID. Added a regression test that confirms a tampered hash throws `InitialStateOfDIDChanged`.

**Note:** Couldn't run the full test suite locally due to a workspace dependency issue with `@hyperledger/identus-protos`.

### Alternatives Considered (optional)

None.

### Checklist
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)