### PR TITLE
feat(jwt): add nbf claim validation

### DIFF
--- a/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
@@ -62,6 +62,16 @@ export class JWT extends Task.Runner {
 
       const decoded = await this.decode(jws);
 
+      // Validate nbf (not before) claim if present
+      if (decoded.payload.nbf !== undefined && typeof decoded.payload.nbf === 'number') {
+        const currentTime = Math.floor(Date.now() / 1000);
+        if (currentTime < decoded.payload.nbf) {
+          throw new PolluxError.InvalidCredentialError(
+            `JWT cannot be used before: ${new Date(decoded.payload.nbf * 1000).toISOString()}`
+          );
+        }
+      }
+
       for (const verificationMethod of verificationMethods) {
         try {
           const pk = await this.runTask(new PKInstance({ verificationMethod }));

--- a/packages/lib/sdk/tests/pollux/JWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/JWT.test.ts
@@ -204,6 +204,63 @@ describe("Domain - JWT", () => {
 
       expect(result).toBe(false);
     });
+
+    test("nbf claim in future - throws InvalidCredentialError", async () => {
+      const futureTime = Math.floor(Date.now() / 1000) + 3600; // 1 hour in future
+      const payload = { ...Fixtures.Credentials.JWT.credentialPayload, nbf: futureTime };
+
+      const jws = await sut.signWithDID(
+        Domain.DID.from(payload.iss),
+        payload,
+        {},
+        Fixtures.Keys.secp256K1.privateKey
+      );
+
+      const result = sut.verify({
+        jws,
+        issuerDID: Domain.DID.from(payload.iss)
+      });
+
+      await expect(result).rejects.toThrow(Domain.PolluxError.InvalidCredentialError);
+      await expect(result).rejects.toMatchObject({ message: expect.stringContaining("cannot be used before") });
+    });
+
+    test("nbf claim in past - verification succeeds", async () => {
+      const pastTime = Math.floor(Date.now() / 1000) - 3600; // 1 hour in past
+      const payload = { ...Fixtures.Credentials.JWT.credentialPayload, nbf: pastTime };
+
+      const jws = await sut.signWithDID(
+        Domain.DID.from(payload.iss),
+        payload,
+        {},
+        Fixtures.Keys.secp256K1.privateKey
+      );
+
+      const result = await sut.verify({
+        jws,
+        issuerDID: Domain.DID.from(payload.iss)
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test("nbf claim absent - verification succeeds", async () => {
+      const payload = Fixtures.Credentials.JWT.credentialPayload;
+
+      const jws = await sut.signWithDID(
+        Domain.DID.from(payload.iss),
+        payload,
+        {},
+        Fixtures.Keys.secp256K1.privateKey
+      );
+
+      const result = await sut.verify({
+        jws,
+        issuerDID: Domain.DID.from(payload.iss)
+      });
+
+      expect(result).toBe(true);
+    });
   });
 
   describe("round trip", () => {


### PR DESCRIPTION
## Summary
Add nbf (not before) claim validation to JWT.verify() to prevent JWTs from being accepted before their designated time.

## Details
- Validates nbf claim if present in JWT payload
- Throws InvalidCredentialError if current time < nbf
- Includes test cases for future nbf (rejected), past nbf (accepted), and no nbf (accepted)

## Related Issues
Closes #551

## Testing
- Added test: JWT cannot be used before designated time
- Added test: JWT with past nbf is accepted
- Added test: JWT without nbf works normally