### PR TITLE
fix(castor): include HTTP metadata in DIDResolverHttpProxy failures

### DIFF
--- a/packages/lib/sdk/src/castor/resolver/DIDResolverHttpProxy.ts
+++ b/packages/lib/sdk/src/castor/resolver/DIDResolverHttpProxy.ts
@@ -2,7 +2,11 @@
 import {
   type DIDResolver,
   DIDDocument,
+  CastorError,
 } from "@hyperledger/identus-domain";
+
+const truncateForError = (text: string, max = 512): string =>
+  text.length > max ? `${text.slice(0, max)}…` : text;
 
 export class DIDResolverHttpProxy implements DIDResolver {
   method: string;
@@ -18,25 +22,60 @@ export class DIDResolverHttpProxy implements DIDResolver {
 
   async resolve(didString: string): Promise<DIDDocument> {
     const url = this.resolverEndpoint + didString;
-    const response = await fetch(url, {
-      "headers": {
-        "accept": "*/*",
-        "accept-language": "en",
-        "cache-control": "no-cache",
-        "pragma": "no-cache",
-        "sec-gpc": "1"
-      },
-      "method": "GET",
-      "mode": "cors",
-      "credentials": "omit"
-    })
-    if (!response.ok) {
-      throw new Error('Failed to fetch data');
+
+    let response: Response;
+
+    try {
+      response = await fetch(url, {
+        "headers": {
+          "accept": "*/*",
+          "accept-language": "en",
+          "cache-control": "no-cache",
+          "pragma": "no-cache",
+          "sec-gpc": "1"
+        },
+        "method": "GET",
+        "mode": "cors",
+        "credentials": "omit"
+      });
     }
-    const didDocumentJson = await response.json();
+    catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new CastorError.NotPossibleToResolveDID(
+        `HTTP DID resolver request failed for "${url}": ${cause}`
+      );
+    }
 
-    const resolved = DIDDocument.fromJSON(didDocumentJson)
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      throw new CastorError.NotPossibleToResolveDID(
+        `DID resolver returned HTTP ${response.status} ${response.statusText} for "${url}"${errorBody.length > 0
+          ? `: ${truncateForError(errorBody)}`
+          : ""
+        }`
+      );
+    }
 
-    return resolved;
+    const rawBody = await response.text();
+
+    let didDocumentJson: unknown;
+    try {
+      didDocumentJson = JSON.parse(rawBody);
+    }
+    catch {
+      throw new CastorError.NotPossibleToResolveDID(
+        `DID resolver returned invalid JSON (${response.status})${rawBody.length > 0 ? `: ${truncateForError(rawBody)}` : ""}`
+      );
+    }
+
+    try {
+      return DIDDocument.fromJSON(didDocumentJson);
+    }
+    catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new CastorError.NotPossibleToResolveDID(
+        `Unable to interpret resolver response as DID document: ${cause}`
+      );
+    }
   }
 }

--- a/packages/lib/sdk/tests/castor/DIDResolverHttpProxy.test.ts
+++ b/packages/lib/sdk/tests/castor/DIDResolverHttpProxy.test.ts
@@ -1,0 +1,112 @@
+import { CastorError, DIDDocument } from '@hyperledger/identus-domain';
+import { describe, expect, test, vi, afterEach } from 'vitest';
+
+import { DIDResolverHttpProxy } from '../../src/castor/resolver/DIDResolverHttpProxy';
+
+describe('DIDResolverHttpProxy', () => {
+  const endpoint = 'https://resolver.example/';
+  const did = 'did:example:123';
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test('maps fetch rejection to NotPossibleToResolveDID', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('failed to fetch'))
+    );
+
+    const resolver = new DIDResolverHttpProxy(endpoint, 'prism');
+
+    await expect(async () => {
+      await resolver.resolve(did);
+    }).rejects.toSatisfy(
+      (err: unknown): err is CastorError.NotPossibleToResolveDID =>
+        err instanceof CastorError.NotPossibleToResolveDID &&
+        /HTTP DID resolver request failed/u.test(err.message)
+    );
+  });
+
+  test('includes HTTP status and body snippet on unsuccessful response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'boom' }), {
+          status: 502,
+          statusText: 'Bad Gateway',
+        })
+      )
+    );
+
+    const resolver = new DIDResolverHttpProxy(endpoint, 'prism');
+
+    await expect(async () => {
+      await resolver.resolve(did);
+    }).rejects.toSatisfy(
+      (err: unknown): err is CastorError.NotPossibleToResolveDID =>
+        err instanceof CastorError.NotPossibleToResolveDID &&
+        /HTTP 502 Bad Gateway/u.test(err.message) &&
+        /boom/u.test(err.message)
+    );
+  });
+
+  test('surfaces invalid JSON payloads from the resolver endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{ not-json', { status: 200 }))
+    );
+
+    const resolver = new DIDResolverHttpProxy(endpoint, 'prism');
+
+    await expect(async () => {
+      await resolver.resolve(did);
+    }).rejects.toMatchObject({
+      message: expect.stringMatching(/invalid JSON/u),
+    });
+  });
+
+  test('parses DID document JSON on success', async () => {
+    const docJson = {
+      id: 'did:example:abcdef',
+      verificationMethod: [],
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(docJson), {
+          status: 200,
+        })
+      )
+    );
+
+    const resolver = new DIDResolverHttpProxy(endpoint, 'prism');
+    const resolved = await resolver.resolve(docJson.id);
+
+    expect(resolved).toBeInstanceOf(DIDDocument);
+    expect(resolved.id.toString()).toBe(docJson.id);
+  });
+
+  test('wraps DID document parsing failures', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: '' }), {
+          status: 200,
+        })
+      )
+    );
+
+    const resolver = new DIDResolverHttpProxy(endpoint, 'prism');
+
+    await expect(async () => {
+      await resolver.resolve(did);
+    }).rejects.toSatisfy(
+      (err: unknown): err is CastorError.NotPossibleToResolveDID =>
+        err instanceof CastorError.NotPossibleToResolveDID &&
+        /Unable to interpret resolver response as DID document/u.test(err.message)
+    );
+  });
+});


### PR DESCRIPTION
### Description

HTTP-backed DID resolution via `DIDResolverHttpProxy` treated almost all failures as a single `Error('Failed to fetch data')`, so callers lost **HTTP status**, **status text**, resolver **URL**, **response body snippets**, and distinctions between **transport errors**, **bad HTTP responses**, **invalid JSON**, and **DID document parse errors**.

This PR routes those cases through **`CastorError.NotPossibleToResolveDID`** with messages that include HTTP metadata (and a truncated body where available), wraps `fetch` rejections with the request URL, parses **200** bodies with `text` + `JSON.parse` so failures are explicit, and wraps `DIDDocument.fromJSON` failures. It adds **Vitest** coverage with a stubbed `fetch` for transport failure, HTTP error, invalid JSON, successful minimal DID document JSON, and malformed document JSON.

**Files:** `packages/lib/sdk/src/castor/resolver/DIDResolverHttpProxy.ts`, `packages/lib/sdk/tests/castor/DIDResolverHttpProxy.test.ts`.

### Alternatives Considered (optional)

- **Keep throwing generic `Error`:** Would avoid a breaking type change for callers that only catch `Error`, but `NotPossibleToResolveDID` extends `Error`, so `catch (e)` remains valid while improving diagnosability.
- **Separate error classes per failure mode:** Clearer typing, but heavier API surface; a single resolver failure type with a descriptive message was chosen for a small, reviewable PR.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/sdk-ts/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)