### PR TITLE
perf(edge-agent): add configurable maximum response body bytes to FetchApi

### DIFF
--- a/packages/lib/sdk/src/edge-agent/Agent.ts
+++ b/packages/lib/sdk/src/edge-agent/Agent.ts
@@ -87,7 +87,7 @@ export class Agent<
     public readonly pluto: Domain.Pluto,
     public readonly mercury: Domain.Mercury,
     public readonly seed: () => Promise<Uint8Array>,
-    public readonly api: Domain.Api = new FetchApi(),
+    public readonly api: Domain.Api = new FetchApi({ maxResponseBodyBytes: 0 }),
     private readonly options?: AgentOptions
   ) {
     super();
@@ -137,7 +137,7 @@ export class Agent<
     options?: AgentOptions;
   }): Agent<ExtraMethods> {
     const pluto = params.pluto;
-    const api = params.api ?? new FetchApi();
+    const api = params.api ?? new FetchApi({ maxResponseBodyBytes: 0 });
     const apollo = params.apollo ?? new Apollo();
     const extraMethods = (params.didMethods ?? params.options?.didMethods) as ExtraMethods | undefined;
     const castor = params.castor ?? new Castor<ExtraMethods>(apollo, extraMethods);

--- a/packages/lib/sdk/src/edge-agent/helpers/FetchApi.ts
+++ b/packages/lib/sdk/src/edge-agent/helpers/FetchApi.ts
@@ -1,9 +1,41 @@
-import { type Api, type HttpMethod, ApiResponse, ApiError } from "@hyperledger/identus-domain";
+import {
+  type Api,
+  type HttpMethod,
+  ApiResponse,
+  ApiError,
+} from "@hyperledger/identus-domain";
+
+/**
+ * Default ceiling for how many bytes of an HTTP response body {@link FetchApi} will buffer
+ * before JSON parsing. Oversized responses trigger {@link ApiError} with status 413.
+ *
+ * Pass `maxResponseBodyBytes: 0` to {@link FetchApi | the constructor} for no limit.
+ */
+export const FETCH_API_DEFAULT_MAX_RESPONSE_BODY_BYTES = 10 * 1024 * 1024;
+
+export type FetchApiOptions = {
+  /**
+   * Maximum number of bytes read from a response body. Responses larger than this raise
+   * {@link ApiError} (HTTP status 413).
+   * Use `0` to disable the limit.
+   */
+  maxResponseBodyBytes?: number;
+};
 
 /**
  * Implement API using built in fetch
  */
 export class FetchApi implements Api {
+  private readonly maxResponseBodyBytes: number;
+
+  constructor(options?: FetchApiOptions) {
+    const configured = options?.maxResponseBodyBytes;
+    this.maxResponseBodyBytes =
+      configured !== undefined
+        ? configured
+        : FETCH_API_DEFAULT_MAX_RESPONSE_BODY_BYTES;
+  }
+
   async request<T>(
     method: HttpMethod,
     urlStr: string,
@@ -48,8 +80,8 @@ export class FetchApi implements Api {
 
   /**
    * should `body` be included in the request
-   * 
-   * @param method 
+   *
+   * @param method
    * @returns {boolean}
    */
   private includeBody(method: HttpMethod): boolean {
@@ -59,18 +91,76 @@ export class FetchApi implements Api {
   /**
    * attempt to convert response to JSON
    * or return as string
-   * 
-   * @param response 
+   *
+   * @param response
    * @returns {string | {}}
    */
   private async parseResponse(response: Response) {
-    const data = await response.text();
+    const data = await this.readResponseBodyText(response);
 
     try {
       return JSON.parse(data);
     }
     catch {
       return data;
+    }
+  }
+
+  /** Read full UTF-8 body text, enforcing {@link FetchApi.maxResponseBodyBytes} when enabled. */
+  private async readResponseBodyText(response: Response): Promise<string> {
+    const limit = this.maxResponseBodyBytes;
+
+    if (limit <= 0) {
+      return response.text();
+    }
+
+    if (!response.body) {
+      const text = await response.text();
+      this.assertBodyWithinLimit(Buffer.byteLength(text, "utf8"), limit);
+      return text;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let totalBytes = 0;
+    let result = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (value) {
+          totalBytes += value.byteLength;
+          if (totalBytes > limit) {
+            await reader.cancel();
+            throw new ApiError(413, "Payload Too Large", {
+              message: `Response body exceeds maximum of ${limit} bytes`,
+            });
+          }
+          result += decoder.decode(value, { stream: true });
+        }
+      }
+    }
+    catch (err) {
+      if (err instanceof ApiError) {
+        throw err;
+      }
+      await reader.cancel().catch(() => undefined);
+      throw err;
+    }
+
+    result += decoder.decode();
+
+    return result;
+  }
+
+  private assertBodyWithinLimit(bodyByteLength: number, limit: number): void {
+    if (bodyByteLength > limit) {
+      throw new ApiError(413, "Payload Too Large", {
+        message: `Response body exceeds maximum of ${limit} bytes`,
+      });
     }
   }
 }

--- a/packages/lib/sdk/src/edge-agent/index.ts
+++ b/packages/lib/sdk/src/edge-agent/index.ts
@@ -3,7 +3,12 @@ export * from "./Agent.Backup";
 export * from "./Agent.MessageEvents";
 export * from "./Context";
 export { CancellableTask } from "./helpers/Task";
-export { FetchApi as ApiImpl } from "./helpers/FetchApi";
+export {
+  FETCH_API_DEFAULT_MAX_RESPONSE_BODY_BYTES,
+  type FetchApiOptions,
+  FetchApi,
+  FetchApi as ApiImpl,
+} from "./helpers/FetchApi";
 export * from "./connections";
 export * from "./types";
 export * from './didFunctions';

--- a/packages/lib/sdk/tests/edge-agent/FetchApi.test.ts
+++ b/packages/lib/sdk/tests/edge-agent/FetchApi.test.ts
@@ -1,0 +1,72 @@
+import { ApiError } from '@hyperledger/identus-domain';
+import { describe, expect, test, vi, afterEach } from 'vitest';
+
+import { FETCH_API_DEFAULT_MAX_RESPONSE_BODY_BYTES, FetchApi } from '../../src/edge-agent/helpers/FetchApi';
+
+describe('FetchApi response body limiting', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test('parses bodies within the configured byte limit', async () => {
+    const bodyText = '{"a":1}';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(bodyText, { status: 200 }))
+    );
+
+    const api = new FetchApi({ maxResponseBodyBytes: FETCH_API_DEFAULT_MAX_RESPONSE_BODY_BYTES });
+    const response = await api.request('GET', 'http://127.0.0.1/example');
+
+    expect(response.body).toEqual({ a: 1 });
+  });
+
+  test('rejects payloads larger than maxResponseBodyBytes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(1000).fill(120));
+              controller.enqueue(new Uint8Array(1000).fill(120));
+              controller.close();
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    const api = new FetchApi({ maxResponseBodyBytes: 1000 });
+
+    await expect(async () => {
+      await api.request('GET', 'http://127.0.0.1/large');
+    }).rejects.toSatisfy(
+      (err: unknown): err is ApiError =>
+        err instanceof ApiError &&
+        err.status === 413
+    );
+  });
+
+  test('maxResponseBodyBytes of 0 disables limiting', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(2500).fill(121));
+              controller.close();
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    const api = new FetchApi({ maxResponseBodyBytes: 0 });
+    await expect(api.request('GET', 'http://127.0.0.1/unbounded')).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Description

`FetchApi` always read the full HTTP response with `response.text()` and then `JSON.parse`, with **no upper bound** on body size. A broken or hostile endpoint could cause **very large allocations** inside the edge agent.

This PR adds a **configurable response body byte limit** (default **10 MiB** via `FETCH_API_DEFAULT_MAX_RESPONSE_BODY_BYTES`). When the stream exceeds the limit, the client throws **`ApiError`** with status **413** and a small JSON `body` payload describing the cap. It reads the body via **`ReadableStream`** (`getReader`) when available so the limit can be enforced **while** reading; if there is no `response.body`, it falls back to `response.text()` and checks size after the fact

**Backward compatibility:** `Agent` continues to use **`new FetchApi({ maxResponseBodyBytes: 0 })`**, which **disables** the cap and preserves the previous unbounded behavior for the default agent path. Direct `new FetchApi()` (no options) uses the **10 MiB** default for defense in depth

**Exports:** `FetchApi`, `FetchApiOptions`, `FETCH_API_DEFAULT_MAX_RESPONSE_BODY_BYTES`, and existing `FetchApi as ApiImpl` remain available from `edge-agent`/`src/edge-agent/index.ts`

**Files:**  
`packages/lib/sdk/src/edge-agent/helpers/FetchApi.ts`, `packages/lib/sdk/src/edge-agent/Agent.ts`, `packages/lib/sdk/src/edge-agent/index.ts`, `packages/lib/sdk/tests/edge-agent/FetchApi.test.ts`

### Alternatives Considered (optional)

- **Always-unlimited `FetchApi` + opt-in limit only:** Fewer surprises for callers of `new FetchApi()`, but weaker defaults for programmatic use outside `Agent`; the chosen split keeps **`Agent`** behavior unchanged while tightening the naked constructor default.
- **`AbortSignal` / timeouts only:** Complementary, not a substitute for buffering caps; limits address memory, not duration alone.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/sdk-ts/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)