### PR TITLE
fix: explicitly request authentication or assertion key or will not g…

### DIFF
--- a/packages/lib/sdk/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
+++ b/packages/lib/sdk/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
@@ -39,8 +39,11 @@ export class FindSigningKeys extends Task<SigningKeyData[], Args> {
       return { privateKey, publicKey, encoded, encodedBase64Url };
     });
 
-    const verificationMethod = this.args.purpose === 'AUTHENTICATION_KEY' ? 'authentication' : 'assertionMethod';
-    const primaryMethods = didDoc[verificationMethod];
+    const verificationMethod =
+      this.args.purpose === 'AUTHENTICATION_KEY' ? 'authentication'
+        : this.args.purpose === 'ISSUING_KEY' ? 'assertionMethod'
+          : null;
+    const primaryMethods = verificationMethod ? didDoc[verificationMethod] : []
     const signingKeyData = this.matchKeys(primaryMethods, keyData);
 
     return signingKeyData;

--- a/packages/lib/sdk/tests/agent/FindDIDSigningKeys.test.ts
+++ b/packages/lib/sdk/tests/agent/FindDIDSigningKeys.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { base58btc } from "multiformats/bases/base58";
+import { base64url } from "multiformats/bases/base64";
+import * as Domain from "@hyperledger/identus-domain";
+
+import {
+  FindSigningKeys,
+  type SigningKeyData,
+} from "../../src/edge-agent/didFunctions/FindDIDSigningKeys";
+import { AgentContext } from "../../src/edge-agent/Context";
+import { Task } from "../../src/utils";
+import * as Fixtures from "../fixtures";
+
+const buildVerificationMethodMultibase = (
+  id: string,
+  privateKey: Domain.PrivateKey,
+): Domain.DIDDocument.VerificationMethod => {
+  const publicKey = privateKey.publicKey();
+  const decoded = Uint8Array.from(publicKey.to.Buffer());
+  return {
+    id,
+    type: "Multikey",
+    controller: "did:prism:test",
+    publicKeyMultibase: base58btc.encode(decoded),
+  } as unknown as Domain.DIDDocument.VerificationMethod;
+};
+
+const buildVerificationMethodJWK = (
+  id: string,
+  privateKey: Domain.PrivateKey,
+  includeY = true,
+): Domain.DIDDocument.VerificationMethod => {
+  const publicKey = privateKey.publicKey();
+  if (!publicKey.isExportable()) {
+    throw new Error("Public key is not exportable");
+  }
+  const jwk = publicKey.to.JWK() as any;
+  const publicKeyJwk: any = {
+    kty: jwk.kty,
+    crv: jwk.crv,
+    x: jwk.x,
+  };
+  if (includeY && jwk.y) {
+    publicKeyJwk.y = jwk.y;
+  }
+  return {
+    id,
+    type: "JsonWebKey2020",
+    controller: "did:prism:test",
+    publicKeyJwk,
+  } as unknown as Domain.DIDDocument.VerificationMethod;
+};
+
+const makeCtx = (overrides: {
+  resolveDID?: (did: Domain.DID) => any;
+  getDIDPrivateKeysByDID?: (did: Domain.DID) => Promise<Domain.PrivateKey[]>;
+  getAllPrismDIDs?: () => Promise<{ did: Domain.DID; privateKey: Domain.PrivateKey }[]>;
+} = {}): AgentContext => {
+  const Castor = {
+    resolveDID:
+      overrides.resolveDID ??
+      vi.fn().mockResolvedValue({ authentication: [], assertionMethod: [] }),
+  } as unknown as Domain.Castor;
+
+  const Pluto = {
+    getDIDPrivateKeysByDID:
+      overrides.getDIDPrivateKeysByDID ?? vi.fn().mockResolvedValue([]),
+    getAllPrismDIDs: overrides.getAllPrismDIDs ?? vi.fn().mockResolvedValue([]),
+  } as unknown as Domain.Pluto;
+
+  return new Task.Context({ Castor, Pluto } as any) as AgentContext;
+};
+
+describe("FindSigningKeys", () => {
+  const did = Fixtures.DIDs.prismDIDDefault;
+  const secpKey = Fixtures.Keys.secp256K1.privateKey;
+  const edKey = Fixtures.Keys.ed25519.privateKey;
+
+  describe("purpose -> verification relationship", () => {
+    test("AUTHENTICATION_KEY uses didDoc.authentication", async () => {
+      const method = buildVerificationMethodMultibase("kid-auth", secpKey);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({
+          authentication: [method],
+          assertionMethod: [
+            buildVerificationMethodMultibase("kid-assertion", edKey),
+          ],
+        }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([secpKey, edKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kid).toBe("kid-auth");
+      expect(result[0].privateKey).toBe(secpKey);
+    });
+
+    test("ISSUING_KEY uses didDoc.assertionMethod", async () => {
+      const authMethod = buildVerificationMethodMultibase("kid-auth", secpKey);
+      const assertionMethod = buildVerificationMethodMultibase(
+        "kid-assertion",
+        edKey,
+      );
+      const resolveDID = vi.fn().mockResolvedValue({
+        authentication: [authMethod],
+        assertionMethod: [assertionMethod],
+      });
+      const ctx = makeCtx({
+        resolveDID,
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([secpKey, edKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "ISSUING_KEY" }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kid).toBe("kid-assertion");
+      expect(result[0].privateKey).toBe(edKey);
+    });
+
+    test("unknown purpose -> empty result", async () => {
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({
+          authentication: [buildVerificationMethodMultibase("kid-auth", secpKey)],
+          assertionMethod: [
+            buildVerificationMethodMultibase("kid-assertion", edKey),
+          ],
+        }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([secpKey, edKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({
+          did,
+          purpose: "SOMETHING_ELSE" as any,
+        }),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("key sourcing (getKeys)", () => {
+    test("uses provided args.privateKey when given", async () => {
+      const method = buildVerificationMethodMultibase("kid-1", secpKey);
+      const getDIDPrivateKeysByDID = vi.fn().mockResolvedValue([edKey]);
+      const getAllPrismDIDs = vi.fn().mockResolvedValue([]);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID,
+        getAllPrismDIDs,
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({
+          did,
+          privateKey: secpKey,
+          purpose: "AUTHENTICATION_KEY",
+        }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].privateKey).toBe(secpKey);
+      expect(getDIDPrivateKeysByDID).not.toHaveBeenCalled();
+      expect(getAllPrismDIDs).not.toHaveBeenCalled();
+    });
+
+    test("falls back to Pluto.getDIDPrivateKeysByDID when no key arg", async () => {
+      const method = buildVerificationMethodMultibase("kid-1", secpKey);
+      const getDIDPrivateKeysByDID = vi.fn().mockResolvedValue([secpKey]);
+      const getAllPrismDIDs = vi.fn().mockResolvedValue([]);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID,
+        getAllPrismDIDs,
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(getDIDPrivateKeysByDID).toHaveBeenCalledWith(did);
+      expect(getAllPrismDIDs).not.toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].privateKey).toBe(secpKey);
+    });
+
+    test("falls back to PrismDIDs filtered by did when getDIDPrivateKeysByDID is empty", async () => {
+      const method = buildVerificationMethodMultibase("kid-1", secpKey);
+      const matchingPrismDID = { did, privateKey: secpKey };
+      const otherDID = Fixtures.DIDs.prismDIDOnlyMaster;
+      const otherPrismDID = { did: otherDID, privateKey: edKey };
+      const getAllPrismDIDs = vi
+        .fn()
+        .mockResolvedValue([matchingPrismDID, otherPrismDID]);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([]),
+        getAllPrismDIDs,
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(getAllPrismDIDs).toHaveBeenCalledOnce();
+      expect(result).toHaveLength(1);
+      expect(result[0].privateKey).toBe(secpKey);
+    });
+
+    test("returns empty when no keys are available from any source", async () => {
+      const method = buildVerificationMethodMultibase("kid-1", secpKey);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([]),
+        getAllPrismDIDs: vi.fn().mockResolvedValue([]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("matchKeys logic", () => {
+    test("matches by publicKeyMultibase and assigns method.id as kid", async () => {
+      const method = buildVerificationMethodMultibase("kid-mb", secpKey);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([secpKey, edKey]),
+      });
+
+      const result: SigningKeyData[] = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kid).toBe("kid-mb");
+      expect(result[0].privateKey).toBe(secpKey);
+      expect(result[0].publicKey).toBeDefined();
+    });
+
+    test("matches by publicKeyJwk including y coordinate", async () => {
+      const method = buildVerificationMethodJWK("kid-jwk-y", secpKey, true);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([secpKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kid).toBe("kid-jwk-y");
+      expect(result[0].privateKey).toBe(secpKey);
+    });
+
+    test("matches by publicKeyJwk without y coordinate (Ed25519)", async () => {
+      const method = buildVerificationMethodJWK("kid-jwk", edKey, false);
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([edKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kid).toBe("kid-jwk");
+      expect(result[0].privateKey).toBe(edKey);
+    });
+
+    test("matches non-exportable keys via curve + base64url-encoded raw bytes", async () => {
+      const publicKey = secpKey.publicKey();
+      const decoded = Uint8Array.from(publicKey.to.Buffer());
+      const encodedX = base64url.baseEncode(decoded);
+
+      const fakePublicKey = {
+        isExportable: () => false,
+        curve: Domain.Curve.SECP256K1,
+        to: { Buffer: () => publicKey.to.Buffer() },
+      } as unknown as Domain.PublicKey;
+
+      const fakePrivateKey = {
+        publicKey: () => fakePublicKey,
+      } as unknown as Domain.PrivateKey;
+
+      const method = {
+        id: "kid-non-exportable",
+        type: "JsonWebKey2020",
+        controller: "did:prism:test",
+        publicKeyJwk: {
+          kty: "EC",
+          crv: Domain.Curve.SECP256K1,
+          x: encodedX,
+        },
+      } as unknown as Domain.DIDDocument.VerificationMethod;
+
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([fakePrivateKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kid).toBe("kid-non-exportable");
+      expect(result[0].privateKey).toBe(fakePrivateKey);
+    });
+
+    test("verification method that has neither multibase nor jwk is skipped", async () => {
+      const method = {
+        id: "kid-empty",
+        type: "Unknown",
+        controller: "did:prism:test",
+      } as unknown as Domain.DIDDocument.VerificationMethod;
+
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({ authentication: [method] }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([secpKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    test("only methods that match a known key are returned", async () => {
+      const matchingMethod = buildVerificationMethodMultibase(
+        "kid-match",
+        secpKey,
+      );
+      const unrelatedKey = Fixtures.Keys.x25519.privateKey;
+      const unmatchedMethod = buildVerificationMethodMultibase(
+        "kid-unrelated",
+        unrelatedKey,
+      );
+
+      const ctx = makeCtx({
+        resolveDID: vi.fn().mockResolvedValue({
+          authentication: [matchingMethod, unmatchedMethod],
+        }),
+        getDIDPrivateKeysByDID: vi.fn().mockResolvedValue([secpKey]),
+      });
+
+      const result = await ctx.run(
+        new FindSigningKeys({ did, purpose: "AUTHENTICATION_KEY" }),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].kid).toBe("kid-match");
+    });
+  });
+});


### PR DESCRIPTION
# Description
Small improvement and test coverage to explicitly check if the signingKey requested in FindSigningKeys is "AUTHENTICATION_KEY" or "ISSUING_KEY"

Before, it would check if its of type authentication only, and default to assertionKey which is generally okey, except if the key is not an ISSUANCE_KEY...

Added tests and very small change

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
