### PR TITLE
fix: explicitly build with command and don't rely on nx dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+yarn clean
+npx nx reset
+
+npx nx run @hyperledger/identus-protos:build --tui false
+npx nx run @hyperledger/identus-domain:build --tui false
+
+npx nx run @hyperledger/identus-anoncreds:build --tui false
+npx nx run @hyperledger/identus-didcomm:build --tui false
+npx nx run @hyperledger/identus-jwe:build --tui false
+
+npx nx run @hyperledger/identus-sdk:build --tui false

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "npx nx run-many --target=build",
-    "build:clean": "npm run clean && npx nx run-many --target=build --skip-nx-cache",
+    "build": "sh build.sh",
     "clean": "npm run clean:generated && npm run clean:build && npm run clean:reset",
     "clean:reset": "npx nx reset",
     "clean:generated": "find packages g -name generated -type d -not -path '*/node_modules/*' -exec rm -rf {} + 2>/dev/null; echo 'All generated folders cleaned'",


### PR DESCRIPTION

### Description
Change the build process to run sh script with explicit dependencies to a void race condition with nx dependency discovery, affecting CI pipeline randomly

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
