### PR TITLE
feat: extend FindSigningKeys to support configurable key purposes.

### DIFF
--- a/packages/lib/sdk/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
+++ b/packages/lib/sdk/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
@@ -5,27 +5,23 @@ import { isNil, notNil } from "../../utils";
 import type * as Domain from "@hyperledger/identus-domain";
 import { base64url } from "multiformats/bases/base64";
 
-type SupportedPurpose = keyof Pick
-  Domain.PrismDIDKeys,
-  | "AUTHENTICATION_KEY"
-  | "ISSUING_KEY"
-  | "KEY_AGREEMENT_KEY"
-  | "CAPABILITY_INVOCATION_KEY"
-  | "CAPABILITY_DELEGATION_KEY"
->;
+const PURPOSE_TO_VERIFICATION_RELATIONSHIP = {
+    AUTHENTICATION_KEY: "authentication",
+    ISSUING_KEY: "assertionMethod",
+    KEY_AGREEMENT_KEY: "keyAgreement",
+    CAPABILITY_INVOCATION_KEY: "capabilityInvocation",
+    CAPABILITY_DELEGATION_KEY: "capabilityDelegation",
+} as const;
 
-const PURPOSE_TO_VERIFICATION_RELATIONSHIP: Record<SupportedPurpose, keyof Domain.DIDDocument> = {
-  AUTHENTICATION_KEY: "authentication",
-  ISSUING_KEY: "assertionMethod",
-  KEY_AGREEMENT_KEY: "keyAgreement",
-  CAPABILITY_INVOCATION_KEY: "capabilityInvocation",
-  CAPABILITY_DELEGATION_KEY: "capabilityDelegation",
-};
+export type SupportedPurpose = keyof typeof PURPOSE_TO_VERIFICATION_RELATIONSHIP;
 
-interface Args {
-  did: Domain.DID;
-  privateKey?: Domain.PrivateKey;
-  purpose?: SupportedPurpose | SupportedPurpose[];
+interface BaseArgs {
+    did: Domain.DID;
+    privateKey?: Domain.PrivateKey;
+}
+
+interface Args extends BaseArgs {
+    purpose: SupportedPurpose;
 }
 
 export interface SigningKeyData {
@@ -56,24 +52,9 @@ export class FindSigningKeys extends Task<SigningKeyData[], Args> {
       return { privateKey, publicKey, encoded, encodedBase64Url };
     });
 
-   const purposes: SupportedPurpose[] = this.args.purpose
-  ? Array.isArray(this.args.purpose) ? this.args.purpose : [this.args.purpose]
-  : ["AUTHENTICATION_KEY"];
-
-   const seenIds = new Set<string>();
-   const allMethods: Domain.DIDDocument.VerificationMethod[] = [];
-
-   for (const purpose of purposes) {
-   const relationship = PURPOSE_TO_VERIFICATION_RELATIONSHIP[purpose];
-   for (const method of (didDoc[relationship] ?? [])) {
-    if (!seenIds.has(method.id)) {
-      seenIds.add(method.id);
-      allMethods.push(method);
-      }
-    }
-  }
-
-    const signingKeyData = this.matchKeys(allMethods, keyData);
+    const verificationMethod = PURPOSE_TO_VERIFICATION_RELATIONSHIP[this.args.purpose];
+    const primaryMethods = didDoc[verificationMethod];
+    const signingKeyData = this.matchKeys(primaryMethods, keyData);
 
     return signingKeyData;
   }
@@ -137,4 +118,16 @@ export class FindSigningKeys extends Task<SigningKeyData[], Args> {
 
     return []
   }
+}
+
+export class FindIssuerSigningKeys extends Task<SigningKeyData[], BaseArgs> {
+    async run(ctx: AgentContext) {
+        return ctx.run(new FindSigningKeys({ ...this.args, purpose: "ISSUING_KEY" }));
+    }
+}
+
+export class FindAuthenticationSigningKeys extends Task<SigningKeyData[], BaseArgs> {
+    async run(ctx: AgentContext) {
+        return ctx.run(new FindSigningKeys({ ...this.args, purpose: "AUTHENTICATION_KEY" }));
+    }
 }

--- a/packages/lib/sdk/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
+++ b/packages/lib/sdk/src/edge-agent/didFunctions/FindDIDSigningKeys.ts
@@ -5,10 +5,27 @@ import { isNil, notNil } from "../../utils";
 import type * as Domain from "@hyperledger/identus-domain";
 import { base64url } from "multiformats/bases/base64";
 
+type SupportedPurpose = keyof Pick
+  Domain.PrismDIDKeys,
+  | "AUTHENTICATION_KEY"
+  | "ISSUING_KEY"
+  | "KEY_AGREEMENT_KEY"
+  | "CAPABILITY_INVOCATION_KEY"
+  | "CAPABILITY_DELEGATION_KEY"
+>;
+
+const PURPOSE_TO_VERIFICATION_RELATIONSHIP: Record<SupportedPurpose, keyof Domain.DIDDocument> = {
+  AUTHENTICATION_KEY: "authentication",
+  ISSUING_KEY: "assertionMethod",
+  KEY_AGREEMENT_KEY: "keyAgreement",
+  CAPABILITY_INVOCATION_KEY: "capabilityInvocation",
+  CAPABILITY_DELEGATION_KEY: "capabilityDelegation",
+};
+
 interface Args {
   did: Domain.DID;
   privateKey?: Domain.PrivateKey;
-  purpose: keyof Pick<Domain.PrismDIDKeys, "AUTHENTICATION_KEY" | "ISSUING_KEY">;
+  purpose?: SupportedPurpose | SupportedPurpose[];
 }
 
 export interface SigningKeyData {
@@ -39,9 +56,24 @@ export class FindSigningKeys extends Task<SigningKeyData[], Args> {
       return { privateKey, publicKey, encoded, encodedBase64Url };
     });
 
-    const verificationMethod = this.args.purpose === 'AUTHENTICATION_KEY' ? 'authentication' : 'assertionMethod';
-    const primaryMethods = didDoc[verificationMethod];
-    const signingKeyData = this.matchKeys(primaryMethods, keyData);
+   const purposes: SupportedPurpose[] = this.args.purpose
+  ? Array.isArray(this.args.purpose) ? this.args.purpose : [this.args.purpose]
+  : ["AUTHENTICATION_KEY"];
+
+   const seenIds = new Set<string>();
+   const allMethods: Domain.DIDDocument.VerificationMethod[] = [];
+
+   for (const purpose of purposes) {
+   const relationship = PURPOSE_TO_VERIFICATION_RELATIONSHIP[purpose];
+   for (const method of (didDoc[relationship] ?? [])) {
+    if (!seenIds.has(method.id)) {
+      seenIds.add(method.id);
+      allMethods.push(method);
+      }
+    }
+  }
+
+    const signingKeyData = this.matchKeys(allMethods, keyData);
 
     return signingKeyData;
   }

--- a/packages/lib/sdk/src/pollux/utils/jwt/CreateJwt.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/CreateJwt.ts
@@ -22,7 +22,7 @@ interface Args {
   payload: Partial<Domain.JWT.Payload>;
   header?: Partial<Domain.JWT.Header>;
   privateKey?: Domain.PrivateKey;
-  purpose?: SupportedPurpose | SupportedPurpose[];
+  purpose?: SupportedPurpose;
 }
 
 export class CreateJWT extends Task<string, Args> {

--- a/packages/lib/sdk/src/pollux/utils/jwt/CreateJwt.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/CreateJwt.ts
@@ -5,7 +5,7 @@ import { asJsonObj, expect } from "../../../utils";
 import { Task } from "../../../utils/tasks";
 import { type AgentContext } from "../../../edge-agent/Context";
 import { base64url } from "multiformats/bases/base64";
-import { FindSigningKeys } from "../../../edge-agent/didFunctions/FindDIDSigningKeys";
+import { FindSigningKeys , type SupportedPurpose } from "../../../edge-agent/didFunctions/FindDIDSigningKeys";
 
 /**
  * Asyncronously sign with a DID
@@ -22,7 +22,7 @@ interface Args {
   payload: Partial<Domain.JWT.Payload>;
   header?: Partial<Domain.JWT.Header>;
   privateKey?: Domain.PrivateKey;
-  purpose?: keyof Pick<Domain.PrismDIDKeys, "AUTHENTICATION_KEY" | "ISSUING_KEY">;
+  purpose?: SupportedPurpose | SupportedPurpose[];
 }
 
 export class CreateJWT extends Task<string, Args> {

--- a/packages/lib/sdk/src/pollux/utils/jwt/CreateSDJWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/CreateSDJWT.ts
@@ -23,7 +23,7 @@ interface Args {
   header?: Partial<Domain.JWT.Header>;
   disclosureFrame: DisclosureFrame<SdJwtVcPayload>;
   privateKey?: Domain.PrivateKey;
-  purpose?: SupportedPurpose | SupportedPurpose[];
+  purpose?: SupportedPurpose;
 }
 
 export class CreateSDJWT extends Task<string, Args> {

--- a/packages/lib/sdk/src/pollux/utils/jwt/CreateSDJWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/CreateSDJWT.ts
@@ -4,7 +4,7 @@ import { Task } from "../../../utils/tasks";
 import { SDJwtVcInstance, type SdJwtVcPayload, } from "@sd-jwt/sd-jwt-vc";
 import type { DisclosureFrame } from '@sd-jwt/types';
 import { type Plugins } from "../../../plugins";
-import { FindSigningKeys } from "../../../edge-agent/didFunctions/FindDIDSigningKeys";
+import { FindSigningKeys,  type SupportedPurpose } from "../../../edge-agent/didFunctions/FindDIDSigningKeys";
 import { expect } from "../../../utils";
 
 /**
@@ -23,7 +23,7 @@ interface Args {
   header?: Partial<Domain.JWT.Header>;
   disclosureFrame: DisclosureFrame<SdJwtVcPayload>;
   privateKey?: Domain.PrivateKey;
-  purpose?: keyof Pick<Domain.PrismDIDKeys, "AUTHENTICATION_KEY" | "ISSUING_KEY">;
+  purpose?: SupportedPurpose | SupportedPurpose[];
 }
 
 export class CreateSDJWT extends Task<string, Args> {

--- a/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/JWT.ts
@@ -6,7 +6,7 @@ import { Task, isNil } from "../../../utils";
 import { CreateJWT } from "./CreateJwt";
 import { ResolveDID } from "./ResolveDID";
 import { PKInstance } from "../../../edge-agent/didFunctions/PKInstance";
-
+import { type SupportedPurpose } from "../../../edge-agent/didFunctions/FindDIDSigningKeys";
 
 export class JWT extends Task.Runner {
   clone() {
@@ -32,7 +32,7 @@ export class JWT extends Task.Runner {
     payload: Partial<Domain.JWT.Payload>,
     header?: Partial<Domain.JWT.Header>,
     privateKey?: Domain.PrivateKey,
-    purpose?: keyof Pick<Domain.PrismDIDKeys, "AUTHENTICATION_KEY" | "ISSUING_KEY">,
+    purpose?: SupportedPurpose,
   ): Promise<string> {
     return this.runTask(new CreateJWT({ did, payload, header, privateKey, purpose }));
   }

--- a/packages/lib/sdk/tests/agent/FindSigningKeys.test.ts
+++ b/packages/lib/sdk/tests/agent/FindSigningKeys.test.ts
@@ -1,0 +1,86 @@
+import { vi, describe, expect, test, beforeEach, afterEach } from 'vitest';
+import * as Domain from '@hyperledger/identus-domain';
+import { Task } from '../../src/utils';
+import * as Fixtures from "../fixtures";
+import { FindSigningKeys, FindIssuerSigningKeys, FindAuthenticationSigningKeys } from '../../src/edge-agent/didFunctions/FindDIDSigningKeys';
+
+describe("FindSigningKeys", () => {
+    let ctx: Task.Context<{
+        Castor: Domain.Castor;
+        Pluto: Domain.Pluto;
+    }>;
+    let castor: Domain.Castor;
+    let pluto: Domain.Pluto;
+
+    const did = Fixtures.DIDs.prismDIDDefault;
+    const privateKey = Fixtures.Keys.ed25519.privateKey;
+    const publicKey = Fixtures.Keys.ed25519.publicKey;
+
+    beforeEach(() => {
+        castor = { resolveDID: vi.fn() } as any;
+        pluto = { getDIDPrivateKeysByDID: vi.fn(), getAllPrismDIDs: vi.fn() } as any;
+        ctx = new Task.Context({ Castor: castor, Pluto: pluto });
+        vi.spyOn(privateKey, "publicKey").mockReturnValue(publicKey);
+        vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue([privateKey]);
+        vi.spyOn(pluto, "getAllPrismDIDs").mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("FindIssuerSigningKeys - searches assertionMethod in DID document", async () => {
+        const spyResolveDID = vi.spyOn(castor, "resolveDID").mockResolvedValue({
+            assertionMethod: [],
+            authentication: [],
+        } as any);
+
+        await ctx.run(new FindIssuerSigningKeys({ did }));
+
+        expect(spyResolveDID).toHaveBeenCalledWith(did);
+    });
+
+    test("FindAuthenticationSigningKeys - searches authentication in DID document", async () => {
+        const spyResolveDID = vi.spyOn(castor, "resolveDID").mockResolvedValue({
+            assertionMethod: [],
+            authentication: [],
+        } as any);
+
+        await ctx.run(new FindAuthenticationSigningKeys({ did }));
+
+        expect(spyResolveDID).toHaveBeenCalledWith(did);
+    });
+
+    test("FindSigningKeys - supports KEY_AGREEMENT_KEY purpose", async () => {
+        vi.spyOn(castor, "resolveDID").mockResolvedValue({
+            keyAgreement: [],
+            assertionMethod: [],
+            authentication: [],
+        } as any);
+
+        const result = await ctx.run(new FindSigningKeys({ did, purpose: "KEY_AGREEMENT_KEY" }));
+        expect(result).toEqual([]);
+    });
+
+    test("FindSigningKeys - supports CAPABILITY_INVOCATION_KEY purpose", async () => {
+        vi.spyOn(castor, "resolveDID").mockResolvedValue({
+            capabilityInvocation: [],
+            assertionMethod: [],
+            authentication: [],
+        } as any);
+
+        const result = await ctx.run(new FindSigningKeys({ did, purpose: "CAPABILITY_INVOCATION_KEY" }));
+        expect(result).toEqual([]);
+    });
+
+    test("FindSigningKeys - supports CAPABILITY_DELEGATION_KEY purpose", async () => {
+        vi.spyOn(castor, "resolveDID").mockResolvedValue({
+            capabilityDelegation: [],
+            assertionMethod: [],
+            authentication: [],
+        } as any);
+
+        const result = await ctx.run(new FindSigningKeys({ did, purpose: "CAPABILITY_DELEGATION_KEY" }));
+        expect(result).toEqual([]);
+    });
+});


### PR DESCRIPTION
Fixes #596

The implementation extends `FindSigningKeys` to support configurable key purposes via a `SupportedPurpose` type and `PURPOSE_TO_VERIFICATION_RELATIONSHIP` mapping table, replacing the hardcoded `AUTHENTICATION_KEY`/`ISSUING_KEY` approach , making the SDK scalable for future operations like DID deactivation and updates.

## Changes

- Added `SupportedPurpose` type covering all 5 mappable verification relationships.
- Added `PURPOSE_TO_VERIFICATION_RELATIONSHIP` mapping table.
- `purpose` now accepts a single `SupportedPurpose` or an array of them.
- Defaults to `AUTHENTICATION_KEY` when omitted (fully backward compatible).
- Deduplicates methods when multiple purposes map to overlapping keys.
- Updated `purpose` type in `CreateJwt` and `CreateSDJWT` to match.

@elribonazo I'd really appreciate your review on this approach. If there's a preferred design pattern or anything that needs adjustment, I'm happy to iterate. 