### PR TITLE
fix: remove wrong lowercase in key alg

### DIFF
--- a/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
@@ -13,7 +13,10 @@ import { CreateSDJWT } from "./CreateSDJWT";
 import { PKInstance } from "../../../edge-agent/didFunctions/PKInstance";
 
 export const defaultHashConfig = {
-  hasherAlg: 'SHA256',
+  // IANA Hash Function Algorithm Name (RFC 6920); SD-JWT spec mandates this
+  // form (lowercase, dashed) for the `_sd_alg` claim. The `hasher` callback
+  // below normalises any reasonable variant so local hashing remains tolerant.
+  hasherAlg: 'sha-256',
   hasher: (data: string | Uint8Array, alg: string) => {
     const safeAlg = alg.replace(/-/gmi, "").toUpperCase();
     if (safeAlg === 'SHA256') {
@@ -120,7 +123,7 @@ export class SDJWT extends Task.Runner {
 
   public getPKConfig(publicKey: Domain.PublicKey): SDJWTVCConfig {
     return {
-      hashAlg: defaultHashConfig.hasherAlg.toLocaleLowerCase(),
+      hashAlg: defaultHashConfig.hasherAlg,
       hasher: defaultHashConfig.hasher,
       signAlg: publicKey.alg,
       verifier: async (data: string | Uint8Array, signatureEncoded: string) => {
@@ -154,7 +157,7 @@ export class SDJWT extends Task.Runner {
 
   public getSKConfig(privateKey: Domain.PrivateKey): SDJWTVCConfig {
     return {
-      hashAlg: defaultHashConfig.hasherAlg.toLocaleLowerCase(),
+      hashAlg: defaultHashConfig.hasherAlg,
       hasher: defaultHashConfig.hasher,
       signAlg: privateKey.alg,
       signer: async (data: string | Uint8Array) => {

--- a/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
+++ b/packages/lib/sdk/src/pollux/utils/jwt/SDJWT.ts
@@ -122,7 +122,7 @@ export class SDJWT extends Task.Runner {
     return {
       hashAlg: defaultHashConfig.hasherAlg.toLocaleLowerCase(),
       hasher: defaultHashConfig.hasher,
-      signAlg: publicKey.alg.toLocaleLowerCase(),
+      signAlg: publicKey.alg,
       verifier: async (data: string | Uint8Array, signatureEncoded: string) => {
         if (!publicKey.canVerify()) {
           throw new PolluxError.InvalidCredentialError("Cannot verify with this key: key does not support verification");
@@ -156,7 +156,7 @@ export class SDJWT extends Task.Runner {
     return {
       hashAlg: defaultHashConfig.hasherAlg.toLocaleLowerCase(),
       hasher: defaultHashConfig.hasher,
-      signAlg: privateKey.alg.toLocaleLowerCase(),
+      signAlg: privateKey.alg,
       signer: async (data: string | Uint8Array) => {
         if (!privateKey.isSignable()) {
           throw new PolluxError.InvalidCredentialError("Cannot sign with this key: key does not support signing");

--- a/packages/lib/sdk/tests/pollux/JWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/JWT.test.ts
@@ -351,4 +351,46 @@ describe("Domain - JWT", () => {
       expect(verified).to.be.true;
     });
   });
+
+  // Regression: JWT header `alg` must be the spec-compliant JWT_ALG value
+  // (e.g. "EdDSA", "ES256K") and never the lowercased form. See RFC 7518 /
+  // RFC 8037. The SDJWT path has equivalent coverage in SDJWT.test.ts.
+  describe("alg casing", () => {
+    const issuerDID = Fixtures.DIDs.prismDIDDefault;
+
+    beforeEach(() => {
+      vi.spyOn(plutoMock, "getDIDPrivateKeysByDID").mockResolvedValue([
+        Fixtures.Keys.secp256K1.privateKey,
+        Fixtures.Keys.ed25519.privateKey,
+      ]);
+    });
+
+    test("Ed25519 - header.alg is exactly 'EdDSA'", async () => {
+      const jws = await sut.signWithDID(
+        issuerDID,
+        {},
+        {},
+        Fixtures.Keys.ed25519.privateKey,
+      );
+      const decoded = await sut.decode(jws);
+
+      expect(decoded.header).toHaveProperty('alg', Domain.JWT_ALG.EdDSA);
+      expect(decoded.header.alg).to.eq("EdDSA");
+      expect(decoded.header.alg).not.to.eq("eddsa");
+    });
+
+    test("Secp256k1 - header.alg is exactly 'ES256K'", async () => {
+      const jws = await sut.signWithDID(
+        issuerDID,
+        {},
+        {},
+        Fixtures.Keys.secp256K1.privateKey,
+      );
+      const decoded = await sut.decode(jws);
+
+      expect(decoded.header).toHaveProperty('alg', Domain.JWT_ALG.ES256K);
+      expect(decoded.header.alg).to.eq("ES256K");
+      expect(decoded.header.alg).not.to.eq("es256k");
+    });
+  });
 });

--- a/packages/lib/sdk/tests/pollux/SDJWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/SDJWT.test.ts
@@ -144,9 +144,11 @@ describe("Domain - SDJWT", () => {
     });
   });
 
-  // Regression: signAlg must be the spec-compliant JWT_ALG value (e.g. "EdDSA",
-  // "ES256K") and never the lowercased form. The SD-JWT header `alg` is taken
-  // verbatim from this value, so lowercasing here breaks RFC 7518 / RFC 8037.
+  // Regression: `signAlg` and `hashAlg` returned by getSKConfig/getPKConfig
+  // must be spec-compliant values - they land verbatim in the SD-JWT header
+  // (`alg`) and the `_sd_alg` claim respectively.
+  // - signAlg: RFC 7518 / RFC 8037 (`EdDSA`, `ES256K`) - case sensitive.
+  // - hashAlg: IANA Hash Function Algorithm Names (`sha-256`) - lowercase + dash.
   describe("config alg", () => {
     let plain: SDJWT;
 
@@ -184,6 +186,24 @@ describe("Domain - SDJWT", () => {
       expect(config.signAlg).to.eq(Domain.JWT_ALG.ES256K);
       expect(config.signAlg).to.eq("ES256K");
       expect(config.signAlg).not.to.eq("es256k");
+    });
+
+    test("getSKConfig - hashAlg is the IANA name 'sha-256'", () => {
+      const config = plain.getSKConfig(Fixtures.Keys.ed25519.privateKey);
+
+      expect(config.hashAlg).to.eq("sha-256");
+      expect(config.hashAlg).not.to.eq("sha256");
+      expect(config.hashAlg).not.to.eq("SHA256");
+      expect(config.hashAlg).not.to.eq("SHA-256");
+    });
+
+    test("getPKConfig - hashAlg is the IANA name 'sha-256'", () => {
+      const config = plain.getPKConfig(Fixtures.Keys.ed25519.publicKey);
+
+      expect(config.hashAlg).to.eq("sha-256");
+      expect(config.hashAlg).not.to.eq("sha256");
+      expect(config.hashAlg).not.to.eq("SHA256");
+      expect(config.hashAlg).not.to.eq("SHA-256");
     });
   });
 });

--- a/packages/lib/sdk/tests/pollux/SDJWT.test.ts
+++ b/packages/lib/sdk/tests/pollux/SDJWT.test.ts
@@ -143,4 +143,47 @@ describe("Domain - SDJWT", () => {
       expect(instance.args.purpose).toBe("AUTHENTICATION_KEY");
     });
   });
+
+  // Regression: signAlg must be the spec-compliant JWT_ALG value (e.g. "EdDSA",
+  // "ES256K") and never the lowercased form. The SD-JWT header `alg` is taken
+  // verbatim from this value, so lowercasing here breaks RFC 7518 / RFC 8037.
+  describe("config alg", () => {
+    let plain: SDJWT;
+
+    beforeEach(() => {
+      plain = new SDJWT();
+    });
+
+    test("getSKConfig - Ed25519 - signAlg is EdDSA", () => {
+      const config = plain.getSKConfig(Fixtures.Keys.ed25519.privateKey);
+
+      expect(config.signAlg).to.eq(Domain.JWT_ALG.EdDSA);
+      expect(config.signAlg).to.eq("EdDSA");
+      expect(config.signAlg).not.to.eq("eddsa");
+    });
+
+    test("getSKConfig - Secp256k1 - signAlg is ES256K", () => {
+      const config = plain.getSKConfig(Fixtures.Keys.secp256K1.privateKey);
+
+      expect(config.signAlg).to.eq(Domain.JWT_ALG.ES256K);
+      expect(config.signAlg).to.eq("ES256K");
+      expect(config.signAlg).not.to.eq("es256k");
+    });
+
+    test("getPKConfig - Ed25519 - signAlg is EdDSA", () => {
+      const config = plain.getPKConfig(Fixtures.Keys.ed25519.publicKey);
+
+      expect(config.signAlg).to.eq(Domain.JWT_ALG.EdDSA);
+      expect(config.signAlg).to.eq("EdDSA");
+      expect(config.signAlg).not.to.eq("eddsa");
+    });
+
+    test("getPKConfig - Secp256k1 - signAlg is ES256K", () => {
+      const config = plain.getPKConfig(Fixtures.Keys.secp256K1.publicKey);
+
+      expect(config.signAlg).to.eq(Domain.JWT_ALG.ES256K);
+      expect(config.signAlg).to.eq("ES256K");
+      expect(config.signAlg).not.to.eq("es256k");
+    });
+  });
 });


### PR DESCRIPTION

### Description

Fixes wrong key alg in sdjwt, identified by @FabioPinheiro.
The alg value will now respect compliant key algorithm, in uppercase EdDSA, etc

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
