### PR TITLE
fix: remove coveralls on merge group tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         run: yarn npm audit --environment production --severity moderate
 
       - name: Coveralls
+        if: github.event_name != 'merge_group'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: coverallsapp/github-action@v2
@@ -74,6 +75,7 @@ jobs:
           file: "coverage/lcov.info"
 
       - name: Coverage Comment
+        if: github.event_name == 'pull_request'
         uses: MishaKav/jest-coverage-comment@v1.0.23
         with:
           coverage-summary-path: coverage/coverage-summary.json


### PR DESCRIPTION

### Description

Fix making coveralls task run only on pull requests but not on merge queue, most important changes are building, testing and DCO 

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
