### PR TITLE
fix: restore baseUrl removed in 5fb0e3055752aea9cf8712cdeafa41169f5b45cb

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,7 @@
       "ES2022",
       "dom"
     ],
+    "baseUrl": ".",
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION

### Description

An issue raised from the previous rc.7 version to rc.8 a regression, the reason why this happens, is that in merged commit [PR](https://github.com/hyperledger-identus/sdk-ts/commit/5fb0e3055752aea9cf8712cdeafa41169f5b45cb)



This broke the module resolution, and types of domain and didcomm modules which should be injected no longer are.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
