### PR TITLE
fix(dif): handle optional and const filters in validateField

### DIFF
--- a/packages/lib/sdk/src/plugins/internal/dif/PresentationVerify.ts
+++ b/packages/lib/sdk/src/plugins/internal/dif/PresentationVerify.ts
@@ -235,6 +235,10 @@ export class PresentationVerify extends Plugins.Task<Args> {
 
       const value = mapper.getValue(path);
 
+      if (value !== null && !field.filter) {
+        return true;
+      }
+
       if (field.filter && value !== null) {
         const filter = field.filter;
 
@@ -257,7 +261,7 @@ export class PresentationVerify extends Plugins.Task<Args> {
             return true
           }
 
-        } else if (filter.const && value === filter.pattern) {
+        } else if (filter.const !== undefined) {
           if (value !== filter.const) {
             throw new Domain.PolluxError.InvalidVerifyCredentialError(
               vc, `Invalid Claim: Expected the ${path} field to be "${JSON.stringify(filter.const)}" but got "${value}"`

--- a/packages/lib/sdk/src/plugins/internal/dif/types.ts
+++ b/packages/lib/sdk/src/plugins/internal/dif/types.ts
@@ -44,7 +44,7 @@ export namespace DIF {
           type: string,
           pattern?: string,
           enum?: PredicateType[],
-          const?: PredicateType[],
+          const?: PredicateType,
           value?: PredicateType,
         }
       }

--- a/packages/lib/sdk/tests/plugins/dif/PresentationVerify.test.ts
+++ b/packages/lib/sdk/tests/plugins/dif/PresentationVerify.test.ts
@@ -150,6 +150,84 @@ describe("Plugins - DIF", () => {
           await expect(result).rejects.toThrow("Verification failed for credential (eyJhbGciOi...): reason -> Invalid Claim: Expected one of the paths $.vc.credentialSubject.not_a_course, $.credentialSubject.not_a_course, $.not_a_course to exist.");
         });
 
+        test("Should verify true when a field has no filter and the path exists (existence check)", async () => {
+          const request: DIF.Presentation.Request = JSON.parse(JSON.stringify(presentationRequest));
+          request.presentation_definition.input_descriptors[0].constraints.fields = [{
+            path: [
+              "$.vc.credentialSubject.course",
+              "$.credentialSubject.course",
+              "$.course",
+            ],
+            id: "no-filter-field",
+            optional: false,
+            name: "course",
+          }];
+          const sut = new PresentationVerify({ presentation, presentationRequest: request });
+          const result = await ctx.run(sut);
+
+          expect(result.data).toBe(true);
+        });
+
+        test("Should verify false when a field has no filter and the path does not exist", async () => {
+          const request: DIF.Presentation.Request = JSON.parse(JSON.stringify(presentationRequest));
+          request.presentation_definition.input_descriptors[0].constraints.fields = [{
+            path: [
+              "$.vc.credentialSubject.nonexistent",
+            ],
+            id: "no-filter-missing",
+            optional: false,
+            name: "nonexistent",
+          }];
+          const sut = new PresentationVerify({ presentation, presentationRequest: request });
+          const result = ctx.run(sut);
+
+          await expect(result).rejects.toThrow("Expected one of the paths $.vc.credentialSubject.nonexistent to exist.");
+        });
+
+        test("Should verify true when a field uses const filter and the value matches", async () => {
+          const request: DIF.Presentation.Request = JSON.parse(JSON.stringify(presentationRequest));
+          request.presentation_definition.input_descriptors[0].constraints.fields = [{
+            path: [
+              "$.vc.credentialSubject.course",
+              "$.credentialSubject.course",
+              "$.course",
+            ],
+            id: "const-match",
+            optional: false,
+            filter: {
+              type: "string",
+              const: "Identus Training course Certification 2024",
+            },
+            name: "course",
+          }];
+          const sut = new PresentationVerify({ presentation, presentationRequest: request });
+          const result = await ctx.run(sut);
+
+          expect(result.data).toBe(true);
+        });
+
+        test("Should verify false when a field uses const filter and the value does not match", async () => {
+          const request: DIF.Presentation.Request = JSON.parse(JSON.stringify(presentationRequest));
+          request.presentation_definition.input_descriptors[0].constraints.fields = [{
+            path: [
+              "$.vc.credentialSubject.course",
+              "$.credentialSubject.course",
+              "$.course",
+            ],
+            id: "const-mismatch",
+            optional: false,
+            filter: {
+              type: "string",
+              const: "wrong value",
+            },
+            name: "course",
+          }];
+          const sut = new PresentationVerify({ presentation, presentationRequest: request });
+          const result = ctx.run(sut);
+
+          await expect(result).rejects.toThrow('Expected the $.vc.credentialSubject.course field to be "\"wrong value\"" but got "Identus Training course Certification 2024"');
+        });
+
         test("Should Verify false when the Credential subject does not match given pattern", async () => {
           const failRequest: DIF.Presentation.Request = JSON.parse(JSON.stringify(presentationRequest));
           failRequest.presentation_definition.input_descriptors[0].constraints.fields = [{


### PR DESCRIPTION
### Description

This PR fixes two spec compliance bugs in `PresentationVerify.validateField` that incorrectly rejected valid presentations:

1. **Accept filter-less fields (existence check):** The code was unconditionally throwing an error if a field lacked a `filter` property. Per DIF Presentation Exchange v2.0, an absent filter means we only need to verify the field exists. Added an early return to pass the check when the path resolves and no filter is defined.
2. **Fix unreachable `const` branch:** The `const` filter logic was dead code because it incorrectly checked `filter.pattern` (which was already handled above it). I updated the guard to check `filter.const !== undefined` and fixed the JSON Schema `const` type definition to be a single value instead of an array.

I also added 4 unit tests to cover existence checks and `const` matches/mismatches.

### Alternatives Considered (optional)

* **For filter-less fields:** Considered enforcing a generic filter mask at the parsing level for fields missing a filter. Rejected because this violates the DIF PE v2.0 spec, which explicitly makes `filter` optional, and it would break compatibility with valid external definitions. 
* **For the `const` type fix:** Considered keeping `const` typed as an array (`PredicateType[]`) and implementing an `includes()` check. Rejected because JSON Schema Validation §6.1.3 strictly defines `const` as a single value (unlike `enum`), so fixing the underlying type definition was the correct approach.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
