### PR TITLE
fix(pollux): fix JWT/SDJWT iat/exp claim units to seconds (RFC 7519)

### DIFF
--- a/packages/lib/sdk/src/plugins/internal/didcomm/tasks/HandleRequestCredential.ts
+++ b/packages/lib/sdk/src/plugins/internal/didcomm/tasks/HandleRequestCredential.ts
@@ -63,8 +63,8 @@ export class HandleRequestCredential extends Task<IssueCredential, Args> {
 
         const payload = {
             iss: issuerDID.toString(),
-            iat: Date.now(),
-            exp: Date.now() + 1000 * 60 * 60 * 24 * 365, //1 year
+            iat: Math.floor(Date.now() / 1000),
+            exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365, //1 year
             nbf: Math.floor(Date.now() / 1000),
             jti: uuid(),
             vc: {
@@ -89,8 +89,8 @@ export class HandleRequestCredential extends Task<IssueCredential, Args> {
     ) {
         const payload = {
             iss: issuerDID.toString(),
-            iat: Date.now(),
-            exp: Date.now() + 1000 * 60 * 60 * 24 * 365, //1 year
+            iat: Math.floor(Date.now() / 1000),
+            exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365, //1 year
             nbf: Math.floor(Date.now() / 1000),
             jti: uuid(),
             vct: issuerDID.toString(),

--- a/packages/lib/sdk/src/plugins/internal/oidc/tasks/CreateCredentialRequest.ts
+++ b/packages/lib/sdk/src/plugins/internal/oidc/tasks/CreateCredentialRequest.ts
@@ -49,7 +49,7 @@ export class CreateCredentialRequest extends Utils.Task<CredentialRequest, Creat
         {
           aud: credentialIssuer,
           iss: clientId,
-          iat: Date.now(),
+          iat: Math.floor(Date.now() / 1000),
           nonce: tokenResponse.c_nonce,
         },
         { typ: "openid4vci-proof+jwt" },

--- a/packages/lib/sdk/tests/agent/HandleRequestCredential.test.ts
+++ b/packages/lib/sdk/tests/agent/HandleRequestCredential.test.ts
@@ -431,6 +431,62 @@ describe("HandleRequestCredential", () => {
         });
     });
 
+    describe("RFC 7519 NumericDate Compliance", () => {
+        test("JWT credential should use seconds for iat/exp claims (RFC 7519)", async () => {
+            const claims = [
+                { name: "name", value: "John Doe", type: "string" }
+            ];
+
+            mockJWT.signWithDID.mockResolvedValue("test-jwt");
+
+            const task = new HandleRequestCredential({
+                issuerDID: Fixtures.DIDs.peerDID2,
+                holderDID: Fixtures.DIDs.peerDID1,
+                message: mockMessage,
+                format: Domain.CredentialType.JWT,
+                claims: claims
+            });
+
+            await ctx.run(task);
+
+            const [, actualPayload] = mockJWT.signWithDID.mock.calls[0];
+
+            expect(actualPayload.iat).toBeLessThan(2_000_000_000);
+            expect(actualPayload.iat).toBeGreaterThan(1_000_000_000);
+            expect(actualPayload.exp).toBeLessThan(2_500_000_000);
+            expect(actualPayload.exp).toBeGreaterThan(1_000_000_000);
+            expect(actualPayload.exp).toBeGreaterThan(actualPayload.iat);
+        });
+
+        test("SDJWT credential should use seconds for iat/exp claims (RFC 7519)", async () => {
+            const claims = [
+                { name: "name", value: "John Doe", type: "string" }
+            ];
+
+            mockSDJWT.sign.mockResolvedValue("test-sdjwt");
+            mockTask(FindSigningKeys, [mockSigningKey]);
+
+            const task = new HandleRequestCredential({
+                issuerDID: Fixtures.DIDs.peerDID2,
+                holderDID: Fixtures.DIDs.peerDID1,
+                message: mockMessage,
+                format: Domain.CredentialType.SDJWT,
+                claims: claims
+            });
+
+            await ctx.run(task);
+
+            const callArgs = mockSDJWT.sign.mock.calls[0][0];
+            const { payload } = callArgs;
+
+            expect(payload.iat).toBeLessThan(2_000_000_000);
+            expect(payload.iat).toBeGreaterThan(1_000_000_000);
+            expect(payload.exp).toBeLessThan(2_500_000_000);
+            expect(payload.exp).toBeGreaterThan(1_000_000_000);
+            expect(payload.exp).toBeGreaterThan(payload.iat);
+        });
+    });
+
     describe("Error Handling", () => {
         test("should throw error for unsupported credential format", async () => {
             const claims = [

--- a/packages/lib/sdk/tests/plugins/oidc/CreateCredentialRequest.test.ts
+++ b/packages/lib/sdk/tests/plugins/oidc/CreateCredentialRequest.test.ts
@@ -87,6 +87,32 @@ describe("OIDC Tasks", () => {
       expect(result.params).not.to.have.property("proof");
     });
 
+    test("OIDC proof JWT should use seconds for iat claim (RFC 7519)", async () => {
+      const mockedJWT = "notajwt";
+      let capturedPayload: any;
+      vi.spyOn(ctx.JWT, "signWithDID").mockImplementation(async (did, payload) => {
+        capturedPayload = payload;
+        return mockedJWT;
+      });
+      mockTask(CreatePrismDID, Fixtures.DIDs.prismDIDDefault);
+
+      const offer = Fixtures.OIDC.credentialOfferJson;
+      const issuerMeta = Fixtures.OIDC.issuerMeta;
+      const clientId = "test-123";
+      const tokenResponse: TokenResponse = {
+        access_token: "9182893",
+        id_token: "idt",
+        c_nonce: "cn",
+        token_type: "tt"
+      };
+
+      const task = new CreateCredentialRequest({ offer, issuerMeta, clientId, tokenResponse });
+      await ctx.run(task);
+
+      expect(capturedPayload.iat).toBeLessThan(2_000_000_000);
+      expect(capturedPayload.iat).toBeGreaterThan(1_000_000_000);
+    });
+
     describe("Errors", () => {
       test("invalid offer - empty credential_configuration_ids - throws", async () => {
         const offer = JSON.parse(JSON.stringify(Fixtures.OIDC.credentialOfferJson));


### PR DESCRIPTION
### Description

Fixes RFC 7519 violation where JWT timestamp claims (`iat` and `exp`) were being emitted as milliseconds instead of seconds (NumericDate format).

This affects:
- JWT credentials issued via `HandleRequestCredential.createJWT()`
- SDJWT credentials issued via `HandleRequestCredential.createSDJWT()` 
- OID4VCI proof JWTs via `CreateCredentialRequest`

**Related Issue:** Fixes #610

### Current Behavior

Tokens are emitted with `iat`/`exp` in milliseconds (~1.7e12), which when interpreted as NumericDate (seconds) correspond to year ~57000. This causes:
- Credentials appear to never expire (exp in far future)
- External RFC 7519-compliant verifiers reject the tokens
- OID4VCI spec-compliant issuers reject the proof

### Expected Behavior

All NumericDate claims conform to RFC 7519 §4.1 by using seconds since Unix epoch. Credentials are now emitted with correct expiration windows and are interoperable with external consumers.

### Changes Made

1. **HandleRequestCredential.ts** (lines 66-67, 92-93)
   - `createJWT()`: Convert `iat: Date.now()` → `iat: Math.floor(Date.now() / 1000)`
   - `createJWT()`: Convert `exp: Date.now() + 1000 * 60 * 60 * 24 * 365` → `exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365`
   - Same fixes applied to `createSDJWT()`

2. **CreateCredentialRequest.ts** (line 52)
   - Convert `iat: Date.now()` → `iat: Math.floor(Date.now() / 1000)` in OID4VCI proof

3. **Tests Added**
   - HandleRequestCredential.test.ts: RFC 7519 NumericDate Compliance tests for JWT and SDJWT
   - CreateCredentialRequest.test.ts: OIDC proof JWT iat seconds validation

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A - no documentation updates needed for bug fix)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All commits are signed with GPG