### PR TITLE
fix(mercury): propagate unpack and protocol handler errors

### DIFF
--- a/packages/lib/sdk/src/mercury/index.ts
+++ b/packages/lib/sdk/src/mercury/index.ts
@@ -133,12 +133,9 @@ export class Mercury implements Domain.Mercury {
     message: Domain.Message
   ): Promise<Domain.Message | undefined> {
     const responseBody = await this.sendMessage<any>(message);
-    try {
-      const responseJSON = JSON.stringify(responseBody);
-      return await this.unpackMessage(responseJSON);
-    } catch {
-      return undefined;
-    }
+    if (!responseBody) return undefined;
+    const responseJSON = JSON.stringify(responseBody);
+    return this.unpackMessage(responseJSON);
   }
 
   private notDid(did: Domain.DID | undefined): did is undefined {

--- a/packages/lib/sdk/src/plugins/internal/didcomm/connection/DIDCommConnection.ts
+++ b/packages/lib/sdk/src/plugins/internal/didcomm/connection/DIDCommConnection.ts
@@ -34,7 +34,6 @@ export class DIDCommConnection implements Connection {
   async receive(message: Domain.Message | undefined, ctx: AgentContext) {
     if (notNil(message)) {
       try {
-        // attempt to find and run the registered handler for this message type
         const result = await ctx.run(new RunProtocol({
           type: "message",
           pid: message?.piuri,
@@ -43,8 +42,11 @@ export class DIDCommConnection implements Connection {
 
         return result;
       }
-      catch {
-        return undefined;
+      catch (err) {
+        if (err instanceof Domain.CommonError.ExpectError) {
+          return undefined;
+        }
+        throw err;
       }
     }
 

--- a/packages/lib/sdk/tests/mercury/Mercury.test.ts
+++ b/packages/lib/sdk/tests/mercury/Mercury.test.ts
@@ -117,5 +117,27 @@ describe("Mercury", () => {
       expect(spyUnpack).toHaveBeenCalledWith(jsonMessage);
       expect(result).to.equal(unpackedMessage);
     });
+
+    it("returns undefined when sendMessage returns a falsy response", async () => {
+      const message = new Message("{}", undefined, "TypeofMessage");
+      vi.spyOn(mercury, "sendMessage").mockResolvedValue(null);
+      const spyUnpack = vi.spyOn(mercury, "unpackMessage");
+
+      const result = await mercury.sendMessageParseMessage(message);
+
+      expect(result).toBeUndefined();
+      expect(spyUnpack).not.toHaveBeenCalled();
+    });
+
+    it("propagates unpackMessage errors when response body is non-null", async () => {
+      const message = new Message("{}", undefined, "TypeofMessage");
+      vi.spyOn(mercury, "sendMessage").mockResolvedValue({ some: "data" });
+      vi.spyOn(mercury, "unpackMessage").mockRejectedValue(
+        new Domain.MercuryError.DidCommError("unpack failed")
+      );
+
+      await expect(mercury.sendMessageParseMessage(message))
+        .rejects.toThrow("unpack failed");
+    });
   });
 });

--- a/packages/lib/sdk/tests/plugins/didcomm/DIDCommConnection.test.ts
+++ b/packages/lib/sdk/tests/plugins/didcomm/DIDCommConnection.test.ts
@@ -1,0 +1,54 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import * as Domain from '@hyperledger/identus-domain';
+import { Message } from '@hyperledger/identus-domain';
+import { DIDCommConnection } from '../../../src/plugins/internal/didcomm/connection/DIDCommConnection';
+
+describe("DIDCommConnection", () => {
+  describe("receive", () => {
+    let connection: DIDCommConnection;
+
+    beforeEach(() => {
+      connection = new DIDCommConnection("uri", "host");
+    });
+
+    it("returns undefined when message is nil", async () => {
+      const ctx = {} as any;
+      const result = await connection.receive(undefined, ctx);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when no protocol handler is registered (ExpectError)", async () => {
+      const message = new Message("{}", undefined, "unknown/piuri");
+      const ctx = {
+        run: vi.fn().mockRejectedValue(
+          new Domain.CommonError.ExpectError("Protocol handler not found for unknown/piuri (message)")
+        ),
+      } as any;
+
+      const result = await connection.receive(message, ctx);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns result when protocol handler succeeds", async () => {
+      const message = new Message("{}", undefined, "test/piuri");
+      const handlerResult = { pid: "test", data: "ok" };
+      const ctx = {
+        run: vi.fn().mockResolvedValue(handlerResult),
+      } as any;
+
+      const result = await connection.receive(message, ctx);
+      expect(result).toEqual(handlerResult);
+    });
+
+    it("propagates non-ExpectError thrown by protocol handler", async () => {
+      const message = new Message("{}", undefined, "test/piuri");
+      const domainError = new Domain.PolluxError.InvalidCredentialError("bad credential");
+      const ctx = {
+        run: vi.fn().mockRejectedValue(domainError),
+      } as any;
+
+      await expect(connection.receive(message, ctx))
+        .rejects.toThrow("bad credential");
+    });
+  });
+});


### PR DESCRIPTION
### Description

`Mercury.sendMessageParseMessage` and `DIDCommConnection.receive` were swallowing errors and returning `undefined`, which made real failures look like empty responses. That hid unpack/decryption issues in Mercury and protocol handler failures in DIDComm.

`sendMessageParseMessage` now returns `undefined` only when the response body is actually empty, and lets unpack errors propagate. `receive` now only catches `ExpectError` for the no-handler case and rethrows everything else. Added tests for the backward-compatible paths and the new error propagation behavior.

#### Behavior Changes

**`sendMessageParseMessage`**
- Unpack/decryption failures now propagate instead of being silently swallowed

**`DIDCommConnection.receive`**
- Handler errors now propagate instead of being silently swallowed
- Only `ExpectError` for missing handlers is still treated as an expected no-response case

### Alternatives Considered

For `receive`, considered rethrowing a list of domain error classes, but catching only `ExpectError` is simpler and automatically covers future error types without maintaining a list.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)