### PR TITLE
fix: restore SD+JWT credentials from backup

### DIFF
--- a/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Backup.ts
+++ b/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Backup.ts
@@ -4,6 +4,7 @@ import { type repositoryFactory } from "../../../repositories/builders/factory";
 import { type IBackupTask } from "../interfaces";
 import { base64url } from "multiformats/bases/base64";
 import { JWTVerifiableCredentialRecoveryId, SDJWTVerifiableCredentialRecoveryId } from "@hyperledger/identus-domain";
+import { SDJWT_VP_PROPS } from "../../../pollux/models/SDJWTVerifiableCredential";
 
 export class BackupTask implements IBackupTask {
   constructor(
@@ -101,7 +102,35 @@ export class BackupTask implements IBackupTask {
     const isJWT = model.recoveryId === JWTVerifiableCredentialRecoveryId;
     const isSDJWT = model.recoveryId === SDJWTVerifiableCredentialRecoveryId;
     const recoveryId = isJWT ? "jwt" : isSDJWT ? "sdjwt" : "anoncred";
-    const data = isJWT || isSDJWT ? JSON.parse(model.dataJson).id : model.dataJson;
+
+    let data: string;
+    if (isJWT) {
+      data = JSON.parse(model.dataJson).id;
+    } else if (isSDJWT) {
+      const parsedData = JSON.parse(model.dataJson);
+      const jwt = parsedData.id;
+      const disclosures = parsedData[SDJWT_VP_PROPS.disclosures] || [];
+
+      // Reconstruct full SDJWT JWS: jwt~disclosure1~disclosure2~...
+      const encodedDisclosures = disclosures.map((disclosure: any) => {
+        if (typeof disclosure === 'string') {
+          return disclosure;
+        }
+        // Disclosure objects have an 'encoded' property containing the base64-encoded disclosure
+        if (disclosure && typeof disclosure === 'object' && 'encoded' in disclosure) {
+          return disclosure.encoded;
+        }
+        // Fallback: try toString() or return as-is
+        if (disclosure && typeof disclosure.toString === 'function') {
+          return disclosure.toString();
+        }
+        return '';
+      });
+
+      data = jwt + '~' + encodedDisclosures.join('~');
+    } else {
+      data = model.dataJson;
+    }
 
     return {
       recovery_id: recoveryId,

--- a/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Backup.ts
+++ b/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Backup.ts
@@ -4,7 +4,7 @@ import { type repositoryFactory } from "../../../repositories/builders/factory";
 import { type IBackupTask } from "../interfaces";
 import { base64url } from "multiformats/bases/base64";
 import { JWTVerifiableCredentialRecoveryId, SDJWTVerifiableCredentialRecoveryId } from "@hyperledger/identus-domain";
-import { SDJWT_VP_PROPS } from "../../../pollux/models/SDJWTVerifiableCredential";
+import { SDJWT_VP_PROPS } from "../../../../pollux/models/SDJWTVerifiableCredential";
 
 export class BackupTask implements IBackupTask {
   constructor(

--- a/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Backup.ts
+++ b/packages/lib/sdk/src/pluto/backup/versions/0_0_1/Backup.ts
@@ -1,4 +1,4 @@
-import type * as Domain from "@hyperledger/identus-domain";
+import * as Domain from "@hyperledger/identus-domain";
 import * as Models from "../../../models";
 import { type repositoryFactory } from "../../../repositories/builders/factory";
 import { type IBackupTask } from "../interfaces";
@@ -105,29 +105,41 @@ export class BackupTask implements IBackupTask {
 
     let data: string;
     if (isJWT) {
-      data = JSON.parse(model.dataJson).id;
-    } else if (isSDJWT) {
-      const parsedData = JSON.parse(model.dataJson);
+      const parsedData = JSON.parse(model.dataJson) as Record<string, unknown>;
       const jwt = parsedData.id;
-      const disclosures = parsedData[SDJWT_VP_PROPS.disclosures] || [];
+      if (typeof jwt !== "string") {
+        throw new Domain.PlutoError.InvalidCredentialJsonError("Invalid JWT credential data");
+      }
+      data = jwt;
+    } else if (isSDJWT) {
+      const parsedData = JSON.parse(model.dataJson) as Record<string, unknown>;
+      const jwt = parsedData.id;
+      const disclosures = parsedData[SDJWT_VP_PROPS.disclosures];
 
-      // Reconstruct full SDJWT JWS: jwt~disclosure1~disclosure2~...
-      const encodedDisclosures = disclosures.map((disclosure: any) => {
-        if (typeof disclosure === 'string') {
+      if (typeof jwt !== "string") {
+        throw new Domain.PlutoError.InvalidCredentialJsonError("Invalid SDJWT credential data");
+      }
+      if (disclosures !== undefined && !Array.isArray(disclosures)) {
+        throw new Domain.PlutoError.InvalidCredentialJsonError("Invalid SDJWT disclosure data");
+      }
+
+      const encodedDisclosures = (disclosures ?? []).map((disclosure) => {
+        if (typeof disclosure === "string") {
           return disclosure;
         }
-        // Disclosure objects have an 'encoded' property containing the base64-encoded disclosure
-        if (disclosure && typeof disclosure === 'object' && 'encoded' in disclosure) {
-          return disclosure.encoded;
+
+        if (disclosure !== null && typeof disclosure === "object") {
+          const serializedDisclosure = disclosure as Record<string, unknown>;
+          const encoded = serializedDisclosure._encoded ?? serializedDisclosure.encoded;
+          if (typeof encoded === "string") {
+            return encoded;
+          }
         }
-        // Fallback: try toString() or return as-is
-        if (disclosure && typeof disclosure.toString === 'function') {
-          return disclosure.toString();
-        }
-        return '';
+
+        throw new Domain.PlutoError.InvalidCredentialJsonError("Invalid SDJWT disclosure data");
       });
 
-      data = jwt + '~' + encodedDisclosures.join('~');
+      data = jwt.includes("~") ? jwt : [jwt, ...encodedDisclosures, ""].join("~");
     } else {
       data = model.dataJson;
     }

--- a/packages/lib/sdk/tests/fixtures/backup.ts
+++ b/packages/lib/sdk/tests/fixtures/backup.ts
@@ -8,6 +8,8 @@ import { credential as anonCredential } from "./credentials/anoncreds";
 import { peerDID4, peerDID5 } from "./dids";
 import { AnonCredsCredential } from "../../src/plugins/internal/anoncreds";
 
+export const credentialJWTEncoded = credentialPayloadEncoded;
+export const credentialSDJWTEncoded = sdjwtCredentialJws;
 export const credentialJWT = JWTCredential.fromJWS(credentialPayloadEncoded);
 export const credentialSDJWT = SDJWTCredential.fromJWS(sdjwtCredentialJws);
 export const credentialAnoncreds = new AnonCredsCredential(anonCredential);

--- a/packages/lib/sdk/tests/fixtures/backup.ts
+++ b/packages/lib/sdk/tests/fixtures/backup.ts
@@ -8,10 +8,18 @@ import { credential as anonCredential } from "./credentials/anoncreds";
 import { peerDID4, peerDID5 } from "./dids";
 import { AnonCredsCredential } from "../../src/plugins/internal/anoncreds";
 
-export const credentialJWTEncoded = credentialPayloadEncoded;
+const sdjwtCredentialWithDisclosuresJwt = [
+  base64url.baseEncode(Buffer.from(JSON.stringify({ typ: "vc+sd-jwt", alg: "none" }))),
+  base64url.baseEncode(Buffer.from(JSON.stringify({ iss: "did:example:issuer", _sd_alg: "sha-256" }))),
+  "signature"
+].join(".");
+const sdjwtCredentialDisclosure = base64url.baseEncode(Buffer.from(JSON.stringify(["salt", "firstname", "Ada"])));
+
 export const credentialSDJWTEncoded = sdjwtCredentialJws;
+export const credentialSDJWTWithDisclosuresEncoded = `${sdjwtCredentialWithDisclosuresJwt}~${sdjwtCredentialDisclosure}~`;
 export const credentialJWT = JWTCredential.fromJWS(credentialPayloadEncoded);
 export const credentialSDJWT = SDJWTCredential.fromJWS(sdjwtCredentialJws);
+export const credentialSDJWTWithDisclosures = SDJWTCredential.fromJWS(credentialSDJWTWithDisclosuresEncoded);
 export const credentialAnoncreds = new AnonCredsCredential(anonCredential);
 export const hostDID = peerDID5;
 export const targetDID = peerDID4;

--- a/packages/lib/sdk/tests/pluto/Pluto.Backup.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.Backup.test.ts
@@ -58,7 +58,28 @@ describe("Pluto", () => {
 
         expect(result.credentials).to.be.an("array").to.have.length(1);
         expect(result.credentials[0]).to.have.property("recovery_id", "sdjwt");
-        expect(result.credentials[0]).to.have.property("data").that.is.a("string");
+        const expectedData = Buffer.from(base64url.baseEncode(Buffer.from(Fixtures.Backup.credentialSDJWTEncoded))).toString();
+        expect(result.credentials[0]).to.have.property("data", expectedData);
+      });
+
+      test("credential - SDJWT with disclosures", async () => {
+        await instance.storeCredential(Fixtures.Backup.credentialSDJWTWithDisclosures);
+
+        const repositories = (instance as any).Repositories;
+        const [model] = await repositories.Credentials.getModels();
+        const credentialData = JSON.parse(model.dataJson) as Record<string, unknown>;
+        credentialData.id = Fixtures.Backup.credentialSDJWTWithDisclosuresEncoded.split("~")[0];
+        await repositories.Credentials.update({
+          ...model,
+          dataJson: JSON.stringify(credentialData),
+        });
+
+        const result = await instance.backup(version);
+
+        expect(result.credentials).to.be.an("array").to.have.length(1);
+        expect(result.credentials[0]).to.have.property("recovery_id", "sdjwt");
+        const expectedData = Buffer.from(base64url.baseEncode(Buffer.from(Fixtures.Backup.credentialSDJWTWithDisclosuresEncoded))).toString();
+        expect(result.credentials[0]).to.have.property("data", expectedData);
       });
 
       test("dids + did_pairs", async () => {
@@ -453,6 +474,7 @@ describe("Pluto", () => {
         expect(dids).not.to.be.null;
 
         expect(credentials).to.have.length(3);
+        expect(credentials.some(credential => credential instanceof SDJWTCredential)).to.be.true;
         // expect(credentials.map(x => (x as any).toStorable())).to.have.deep.members([Fixtures.Backup.credentialAnoncreds.toStorable(), Fixtures.Backup.credentialJWT.toStorable(), Fixtures.Backup.credentialSDJWT.toStorable()]);
 
         expect(dids).to.have.length(2);

--- a/packages/lib/sdk/tests/pluto/Pluto.Backup.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.Backup.test.ts
@@ -58,8 +58,7 @@ describe("Pluto", () => {
 
         expect(result.credentials).to.be.an("array").to.have.length(1);
         expect(result.credentials[0]).to.have.property("recovery_id", "sdjwt");
-        const expectedData = Buffer.from(base64url.baseEncode(Buffer.from(Fixtures.Backup.credentialSDJWT.id))).toString();
-        expect(result.credentials[0]).to.have.property("data", expectedData);
+        expect(result.credentials[0]).to.have.property("data").that.is.a("string");
       });
 
       test("dids + did_pairs", async () => {
@@ -180,7 +179,7 @@ describe("Pluto", () => {
           credentials: [
             {
               recovery_id: "sdjwt",
-              data: Buffer.from(base64url.baseEncode(Buffer.from(Fixtures.Backup.credentialSDJWT.id))).toString(),
+              data: Buffer.from(base64url.baseEncode(Buffer.from(Fixtures.Backup.credentialSDJWTEncoded))).toString(),
             },
           ],
           dids: [],
@@ -421,6 +420,7 @@ describe("Pluto", () => {
 
       test("Backup -> Restore", async () => {
         await instance.storeCredential(Fixtures.Backup.credentialJWT);
+        await instance.storeCredential(Fixtures.Backup.credentialSDJWT);
         await instance.storeCredential(Fixtures.Backup.credentialAnoncreds);
         await instance.storeDIDPair(Fixtures.Backup.hostDID, Fixtures.Backup.targetDID, Fixtures.Backup.pairAlias);
         await instance.storeDID(Fixtures.Backup.hostDID, Fixtures.Backup.peerDIDKeys);
@@ -452,8 +452,8 @@ describe("Pluto", () => {
 
         expect(dids).not.to.be.null;
 
-        expect(credentials).to.have.length(2);
-        // expect(credentials.map(x => (x as any).toStorable())).to.have.deep.members([Fixtures.Backup.credentialAnoncreds.toStorable(), Fixtures.Backup.credentialJWT.toStorable()]);
+        expect(credentials).to.have.length(3);
+        // expect(credentials.map(x => (x as any).toStorable())).to.have.deep.members([Fixtures.Backup.credentialAnoncreds.toStorable(), Fixtures.Backup.credentialJWT.toStorable(), Fixtures.Backup.credentialSDJWT.toStorable()]);
 
         expect(dids).to.have.length(2);
         expect(didPairs).to.have.length(1);


### PR DESCRIPTION
### Description

Fixes #458 - Backup/restore was broken for SD+JWT credentials. The backup function stored only the JWT ID field instead of the full SDJWT JWS (jwt~disclosure1~disclosure2~...), causing restore to fail since `SDJWTCredential.fromJWS()` needs the complete JWS including disclosures to properly recreate the credential.

### Alternatives Considered (optional)

N/A

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)