### PR TITLE
fix(mercury): Secure JWK parsing and message error handling

### DIFF
--- a/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
@@ -13,6 +13,18 @@ const DIDCommMessagingKey = "DIDCommMessaging";
 export class DIDCommDIDResolver implements DIDComm.DIDResolver {
   constructor(private readonly castor: import("@hyperledger/identus-domain").Castor) { }
 
+  private parseJWKCoordinate(jwk: unknown, field: string): string {
+    const { CastorError } = require("@hyperledger/identus-domain");
+    if (typeof jwk !== "object" || jwk === null) {
+      throw new CastorError.InvalidKeyError(`Invalid JWK: not an object`);
+    }
+    const value = (jwk as Record<string, unknown>)[field];
+    if (typeof value !== "string") {
+      throw new CastorError.InvalidKeyError(`Invalid JWK: ${field} is not a string`);
+    }
+    return value;
+  }
+
   /**
    * Resolve a DID string to a DIDComm-compatible DID Document.
    *
@@ -41,8 +53,8 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
               keyAgreements.push(method.id);
               break;
           }
-          const publicKeyBase64 = method.publicKeyJwk?.x as any;
-          const publicKeyKid = (method.publicKeyJwk as any).kid;
+          const publicKeyBase64 = this.parseJWKCoordinate(method.publicKeyJwk, "x");
+          const publicKeyKid = this.parseJWKCoordinate(method.publicKeyJwk, "kid");
           const kty = (curve === Curve.ED25519 || curve === Curve.X25519) ? "OKP" : "EC";
           verificationMethods.push({
             controller: method.controller,

--- a/packages/lib/sdk/src/mercury/index.ts
+++ b/packages/lib/sdk/src/mercury/index.ts
@@ -125,19 +125,28 @@ export class Mercury implements Domain.Mercury {
   /**
    * Asynchronously sends a given message and returns the response message object.
    *
-   * 
+   *
    * @param {Domain.Message} message
    * @returns {Promise<Domain.Message>}
+   * @throws {MercuryError.InvalidMessageFormatError} if the response cannot be unpacked
    */
   async sendMessageParseMessage(
     message: Domain.Message
   ): Promise<Domain.Message | undefined> {
     const responseBody = await this.sendMessage<any>(message);
+
+    if (!responseBody) {
+      return undefined;
+    }
+
     try {
       const responseJSON = JSON.stringify(responseBody);
       return await this.unpackMessage(responseJSON);
-    } catch {
-      return undefined;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw new Domain.MercuryError.InvalidMessageFormatError(
+        `Failed to unpack message response: ${errorMessage}`
+      );
     }
   }
 


### PR DESCRIPTION
## Description

This PR addresses two critical security and reliability issues in the Mercury DIDComm implementation:

1. **Unsafe JWK type casting in DID verification** (#625) - Added strict type validation for JWK coordinate parsing to prevent malformed keys from passing through cryptographic verification layers.

2. **Silent error suppression in message unpacking** (#626) - Replaced silent error swallowing with explicit exception throwing to enable proper error diagnosis in credential issuance/verification flows.

## Changes

### Issue #625: JWK Validation
- Added `parseJWKCoordinate()` helper method with runtime type guards in DIDCommDIDResolver
- Replaces unsafe `as any` casts with validated field extraction
- Throws `InvalidKeyError` for malformed JWK data before reaching cryptographic verification

### Issue #626: Message Error Handling
- Modified `sendMessageParseMessage()` to throw `InvalidMessageFormatError` on unpacking failures
- Distinguishes between empty responses (return undefined) and actual parsing errors (throw exception)
- Updated JSDoc to document the new exception behavior

## Alternatives Considered

- **Silent failure with logging**: Considered adding console/logger calls instead of throwing, but this would require a logger dependency in Mercury and doesn't prevent downstream issues
- **Returning error objects**: Considered wrapping errors in response objects, but throwing is consistent with SDK patterns and forces callers to handle failures

## Checklist

- [x] Follows contribution guidelines (conventional commits, GPG signed)
- [x] No third-party dependency additions
- [x] Complex logic properly documented
- [x] Type safety improvements with runtime validation
- [ ] Tests added (needed for integration tests covering crypto flows)
- [x] PR title follows conventional commit specification

Fixes #625 #626