### PR TITLE
fix(castor): Aggregate and report DID resolution failures with full context

### DIFF
--- a/packages/lib/sdk/src/castor/index.ts
+++ b/packages/lib/sdk/src/castor/index.ts
@@ -143,19 +143,33 @@ export class Castor<
   async resolveDID(didstr: Domain.DID | string): Promise<DIDDocument> {
     const did = Domain.DID.from(didstr);
     const resolvers = this.#resolvers.filter(x => x.method === did.method);
-    let lastError: unknown;
+    const errors: Array<{ resolver: string; error: Error }> = [];
 
     for (const resolver of resolvers) {
       try {
         return await resolver.resolve(did.toString());
       } catch (error) {
-        lastError = error;
-        console.log(`Failed resolving did ${did.toString()}`);
+        errors.push({
+          resolver: resolver.constructor.name,
+          error: error instanceof Error ? error : new Error(String(error))
+        });
       }
     }
-    if (lastError instanceof CastorError.InitialStateOfDIDChanged) {
-      throw lastError;
+
+    // Prioritize InitialStateOfDIDChanged errors as they indicate a state mutation
+    const stateChangeError = errors.find(e =>
+      e.error instanceof CastorError.InitialStateOfDIDChanged
+    );
+    if (stateChangeError) {
+      throw stateChangeError.error;
     }
-    throw new Error(`Non of the available Castor resolvers could resolve the DID '${didstr.toString()}'`);
+
+    // Aggregate resolver failures for better diagnostics
+    const errorDetails = errors
+      .map(e => `${e.resolver}: ${e.error.message}`)
+      .join("; ");
+    throw new CastorError.DIDResolutionError(
+      `Failed to resolve DID '${did.toString()}'. Tried ${errors.length} resolver(s): ${errorDetails}`
+    );
   }
 }


### PR DESCRIPTION
## Description

Improve error handling in DID resolution by aggregating errors from all attempted resolvers and including detailed failure context instead of a generic error message.

## Changes

- Collect errors from each resolver attempt
- Report resolver name and error message for each failure
- Prioritize InitialStateOfDIDChanged errors
- Provide complete diagnostic information in the error message

This enables developers to diagnose root causes (network timeout, invalid DID, blockchain unreachable, etc.) instead of seeing a generic "could not resolve DID" message.

## Example

**Before:**
```
Error: Non of the available Castor resolvers could resolve the DID 'did:prism:123'
```

**After:**
```
DIDResolutionError: Failed to resolve DID 'did:prism:123'. Tried 2 resolver(s): 
PrismResolver: Network timeout; PeerResolver: Invalid DID format
```

## Alternatives Considered

- Adding a logger dependency - this approach uses built-in error messages for better stack traces
- Returning error objects instead of throwing - throwing is consistent with SDK patterns

## Checklist

- [x] Follows contribution guidelines (conventional commits, GPG signed)
- [x] No third-party dependency additions  
- [x] Improves debuggability of credential flows
- [x] PR title follows conventional commit specification

Fixes #629