### PR TITLE
fix(domain): preserve path and query in DIDUrl serialization

### DIFF
--- a/packages/lib/sdk/tests/castor/DIDUrlParser.test.ts
+++ b/packages/lib/sdk/tests/castor/DIDUrlParser.test.ts
@@ -1,8 +1,39 @@
 import { describe, it, expect, test, beforeEach, afterEach } from 'vitest';
+import { DID } from "@hyperledger/identus-domain";
+import { DIDUrl } from "@hyperledger/identus-domain";
 
 import * as DIDUrlParser from "../../src/castor/parser/DIDUrlParser";
 
 describe("DIDUrlParser", () => {
+  it("DIDUrl.string() should include path and query parameters", () => {
+    // BUG: DIDUrl.string() drops path and parameters.
+    // pathString() and queryString() helpers exist but string()
+    // never calls them. Direct construction isolates string()
+    // from the parser entirely.
+
+    const baseDID = DID.fromString("did:prism:123456");
+
+    // Primary case: path + parameters + fragment all present
+    const full = new DIDUrl(
+      baseDID,
+      ["path", "to", "resource"],
+      new Map([["query", "1"]]),
+      "fragment"
+    );
+    expect(full.string()).toBe(
+      "did:prism:123456/path/to/resource?query=1#fragment"
+    );
+
+    // Regression guard: fragment-only must still work
+    const fragmentOnly = new DIDUrl(baseDID, [], new Map(), "fragment");
+    expect(fragmentOnly.string()).toBe("did:prism:123456#fragment");
+
+    // Regression guard: path only, no parameters, no fragment
+    // (also catches the secondary empty-fragment "#" bug)
+    const pathOnly = new DIDUrl(baseDID, ["resource"], new Map(), "");
+    expect(pathOnly.string()).toBe("did:prism:123456/resource");
+  });
+
   it("should test valid URLs", () => {
     const didExample1 = "did:example:123456:adsd/path?query=something#fragment";
     const didExample2 =

--- a/packages/shared/domain/src/models/DIDUrl.ts
+++ b/packages/shared/domain/src/models/DIDUrl.ts
@@ -19,7 +19,10 @@ export class DIDUrl {
   }
 
   string(): string {
-    return `${this.did.toString()}${this.fragmentString()}`;
+    const pathStr = this.path.length > 0 ? this.pathString() : "";
+    const queryStr = this.parameters.size > 0 ? this.queryString() : "";
+    const fragmentStr = this.fragment === "" ? "" : this.fragmentString();
+    return `${this.did.toString()}${pathStr}${queryStr}${fragmentStr}`;
   }
 
   pathString(): string {
@@ -33,6 +36,6 @@ export class DIDUrl {
   }
 
   fragmentString(): string {
-    return `#${this.fragment}`;
+    return this.fragment === "" ? "" : `#${this.fragment}`;
   }
 }


### PR DESCRIPTION
Resolves #634

### Description

This PR fixes an issue in `DIDUrl.string()` where path and query parameters were not included during serialization.

`DIDUrlParser.parse()` already preserves these values correctly, but calling `.string()` on the resulting object dropped them from the final DID URL. This update wires the existing `pathString()` and `queryString()` helpers into `string()` so all parsed components are preserved during serialization.

I also added a small guard in `fragmentString()` to avoid appending a trailing `#` when the fragment is empty.

A regression test has been added to `DIDUrlParser.test.ts` to verify that path, query, and fragment components are serialized correctly.

**Test Evidence:**
Before:
<img width="876" height="501" alt="image" src="https://github.com/user-attachments/assets/1cc6e8a1-2b8d-42e8-ac29-cff742d64278" />

After:
<img width="793" height="650" alt="image" src="https://github.com/user-attachments/assets/2d0a3d9d-6718-46e3-b666-ad92501f0d28" />


### Alternatives Considered (optional)

Another option would have been to refactor the serializer around the native `URL` API, but that felt unnecessary for a localized bug fix and could introduce compatibility concerns in environments like React Native. Keeping the change within the existing string builder methods keeps the fix small and focused.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)