### PR TITLE
fix(pluto): add rollback on partial failure in storeDID, storePrismDID, storePeerDID

### DIFF
--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -448,13 +448,23 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
    */
   async storeDID(did: Domain.DID, keys?: Arrayable<Domain.PrivateKey>, alias?: string) {
     await this.Repositories.DIDs.save(did, alias);
-    for (const key of asArray(keys)) {
-      await this.Repositories.Keys.save(key);
-      await this.Repositories.DIDKeyLinks.insert({
-        alias,
-        didId: did.uuid,
-        keyId: key.uuid
-      });
+    const savedKeys: Domain.PrivateKey[] = [];
+    try {
+      for (const key of asArray(keys)) {
+        await this.Repositories.Keys.save(key);
+        savedKeys.push(key);
+        await this.Repositories.DIDKeyLinks.insert({
+          alias,
+          didId: did.uuid,
+          keyId: key.uuid
+        });
+      }
+    } catch (e) {
+      for (const key of savedKeys) {
+        await this.Repositories.Keys.delete(key.uuid);
+      }
+      await this.Repositories.DIDs.delete(did.uuid);
+      throw e;
     }
   }
 
@@ -469,13 +479,18 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
    */
   async storePrismDID(did: Domain.DID, privateKey: Domain.PrivateKey, alias?: string) {
     await this.Repositories.DIDs.save(did, alias);
-    await this.Repositories.Keys.save(privateKey);
-
-    await this.Repositories.DIDKeyLinks.insert({
-      alias,
-      didId: did.uuid,
-      keyId: privateKey.uuid
-    });
+    try {
+      await this.Repositories.Keys.save(privateKey);
+      await this.Repositories.DIDKeyLinks.insert({
+        alias,
+        didId: did.uuid,
+        keyId: privateKey.uuid
+      });
+    } catch (e) {
+      await this.Repositories.Keys.delete(privateKey.uuid);
+      await this.Repositories.DIDs.delete(did.uuid);
+      throw e;
+    }
   }
 
   /**
@@ -537,9 +552,19 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
    */
   async storePeerDID(did: Domain.DID, privateKeys: Domain.PrivateKey[]) {
     await this.Repositories.DIDs.save(did);
-    for (const key of privateKeys) {
-      await this.Repositories.Keys.save(key);
-      await this.Repositories.DIDKeyLinks.insert({ didId: did.uuid, keyId: key.uuid });
+    const savedKeys: Domain.PrivateKey[] = [];
+    try {
+      for (const key of privateKeys) {
+        await this.Repositories.Keys.save(key);
+        savedKeys.push(key);
+        await this.Repositories.DIDKeyLinks.insert({ didId: did.uuid, keyId: key.uuid });
+      }
+    } catch (e) {
+      for (const key of savedKeys) {
+        await this.Repositories.Keys.delete(key.uuid);
+      }
+      await this.Repositories.DIDs.delete(did.uuid);
+      throw e;
     }
   }
 

--- a/packages/lib/sdk/tests/pluto/Pluto.Atomicity.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.Atomicity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import * as SDK from "../../src";
+import * as Fixtures from "../fixtures";
+import { randomUUID } from 'node:crypto';
+import { createStore } from "../../src/pluto/store";
+
+describe("Pluto Atomicity", () => {
+  let defaultStore: SDK.Pluto.Store;
+  let failingStore: SDK.Pluto.Store;
+  let instance: SDK.Domain.Pluto;
+  let apollo: SDK.Apollo;
+
+  beforeEach(async () => {
+    apollo = new SDK.Apollo();
+    defaultStore = await createStore("test-" + randomUUID());
+    
+    // Create a proxy store that fails on the second write (DIDKeyLink)
+    failingStore = {
+      ...defaultStore,
+      insert: async (table, model) => {
+        if (table === "didkey-link") {
+          throw new Error("Simulated DB Failure on DIDKeyLink");
+        }
+        return defaultStore.insert(table, model);
+      }
+    };
+
+    instance = await SDK.Pluto.create({
+      store: failingStore,
+      keyRestoration: apollo,
+    });
+    await instance.start();
+  });
+
+  test("storeDID should be atomic and not leave orphaned DIDs on partial failure", async () => {
+    // BUG: storeDID performs multiple separate database inserts without a transaction, leaving orphaned records if a later insert fails.
+    const sutDID = SDK.Domain.DID.from("did:prism:atomicity-mock1");
+    const sutKey = new SDK.X25519PrivateKey(Fixtures.Keys.x25519.privateKey.raw);
+
+    // The storeDID call will fail because failingStore throws on "didkey-link" insert
+    let errorCaught = false;
+    try {
+      await instance.storeDID(sutDID, sutKey);
+    } catch (e) {
+      errorCaught = true;
+    }
+    
+    expect(errorCaught).toBe(true);
+
+    // If the operation is atomic, the DID should NOT be in the database
+    // We check the underlying working store for the orphaned DID
+    const orphanedDIDs = await defaultStore.query("dids", { selector: { uuid: sutDID.uuid } });
+    
+    // This expect will FAIL because the code is currently NOT atomic (orphaned DID is left behind)
+    expect(orphanedDIDs).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Resolves #636 

### Description

The `storeDID`, `storePrismDID`, and `storePeerDID` methods in `Pluto.ts` perform multiple sequential database writes (`DIDs.save`, `Keys.save`, `DIDKeyLinks.insert`) without atomicity. Because these writes execute independently, if a later insert (such as the `DIDKeyLink`) fails, the previously written DID and Key records are permanently stranded in the database, causing an inconsistent internal state.

This PR introduces manual rollback logic to these three methods. By wrapping the dependent writes in `try/catch` blocks, we ensure that if any insert fails, the `catch` block explicitly deletes the already-committed records before re-throwing the original error. This restores atomicity and ensures the storage layer never accumulates orphaned data.

Tests after fix:

<img width="850" height="382" alt="image" src="https://github.com/user-attachments/assets/c06bd857-63b1-4c76-a2f5-d4f4872b9cc7" />

<img width="923" height="857" alt="image" src="https://github.com/user-attachments/assets/112efc88-7904-43ad-b9dc-8df30167bd46" />


### Alternatives Considered (optional)

I also looked at adding transaction support to `Pluto.Store`, but that would be a breaking change for every existing store implementation. Keeping the rollback inside `Pluto` fixes the issue without changing the storage interface.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
