### PR TITLE
fix(docs): escape angle-bracketed URL to fix MDX compilation

### DIFF
--- a/docs/decisions/20231110-sdk-package-release.md
+++ b/docs/decisions/20231110-sdk-package-release.md
@@ -4,7 +4,7 @@
 - Deciders: [Javier Ribó](https://github.com/elribonazo) + [Gonçalo](https://github.com/goncalo-frade-iohk)
 - Date: 2023-11-10
 
-Technical Story: <https://input-output.atlassian.net/browse/ATL-6147>
+Technical Story: [ATL-6147](https://input-output.atlassian.net/browse/ATL-6147)
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
## Description

The URL `<https://...>` in `docs/decisions/20231110-sdk-package-release.md` (line 7) was being interpreted as JSX by MDX, causing the Docusaurus build in the [docs](https://github.com/hyperledger-identus/docs) site to fail with:

```
Unexpected character `/` (U+002F) before local name, expected a character 
that can start a name, such as a letter, `$`, or `_` (note: to create a 
link in MDX, use `[text](url)`)
```

## Fix

Replaced the raw angle-bracketed URL with a proper markdown link: `[ATL-6147](https://input-output.atlassian.net/browse/ATL-6147)`

## Related

- Fixes the build failure in https://github.com/hyperledger-identus/docs/pull/259