### PR TITLE
refactor: use Domain.PrivateKey for PeerDIDs

### DIFF
--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -572,15 +572,7 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
     const peerDids = allDids.map(did => {
       const keyIds = allLinks.filter(x => x.didId === did.uuid).map(x => x.keyId);
       const keys = allKeys.filter(x => keyIds.includes(x.uuid));
-
-      const peerDid = new PeerDID(
-        did,
-        // TODO: remove this when PeerDIDs are updated to use PrivateKey
-        keys.map(x => ({
-          keyCurve: getKeyCurveByNameAndIndex(x.curve, x.index),
-          value: x.getEncoded()
-        }))
-      );
+      const peerDid = new PeerDID(did, keys)
 
       return peerDid;
     });

--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -556,7 +556,7 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
       selector: { $or: allLinks.map(x => ({ uuid: x.keyId })) }
     });
 
-    const getKeyCurveByNameAndIndex = (name: string, index?: number): Domain.KeyCurve => {
+    const _getKeyCurveByNameAndIndex = (name: string, index?: number): Domain.KeyCurve => {
       switch (name) {
         case Domain.Curve.X25519.toString():
           return { curve: Domain.Curve.X25519 };

--- a/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
+++ b/packages/lib/sdk/tests/mercury/didcomm/SecretsResolver.test.ts
@@ -94,14 +94,11 @@ describe("Mercury DIDComm SecretsResolver", () => {
       const ecnum = "ecnum123";
       const privateKey = Fixtures.Keys.x25519.privateKey;
       const privateKeys = [
-        {
-          curve: Curve.X25519,
-          value: privateKey.getEncoded(),
-        },
+        Fixtures.Keys.x25519.privateKey
       ];
 
-      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did as any);
-      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys as any);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did);
+      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys);
       vi.spyOn(castor, "resolveDID").mockResolvedValue(
         new Domain.DIDDocument(did, [
           new Domain.DIDDocument.VerificationMethods([
@@ -141,14 +138,11 @@ describe("Mercury DIDComm SecretsResolver", () => {
       const privateKey = Fixtures.Keys.x25519.privateKey;
 
       const privateKeys = [
-        {
-          curve: Curve.X25519,
-          value: privateKey.getEncoded(),
-        },
+        Fixtures.Keys.x25519.privateKey
       ];
 
-      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did as any);
-      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys as any);
+      vi.spyOn(pluto, "getDIDByDIDOrAlias").mockResolvedValue(did);
+      vi.spyOn(pluto, "getDIDPrivateKeysByDID").mockResolvedValue(privateKeys);
       vi.spyOn(castor, "resolveDID").mockResolvedValue(
         new Domain.DIDDocument(did, [
           new Domain.DIDDocument.VerificationMethods([

--- a/packages/lib/sdk/tests/pluto/Pluto.DIDs.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.DIDs.test.ts
@@ -153,8 +153,8 @@ describe("Pluto", () => {
         expect(sutOut?.did.toString()).to.eql(sutDID.toString());
 
         expect(sutOut?.privateKeys).to.have.length(1);
-        expect(sutOut?.privateKeys[0].keyCurve.curve).to.eql(sutKey.curve);
-        expect(sutOut?.privateKeys[0].value).to.eql(sutKey.getEncoded());
+        expect(sutOut?.privateKeys[0].curve).to.eql(sutKey.curve);
+        expect(sutOut?.privateKeys[0]?.getEncoded()).to.eql(sutKey.getEncoded());
       });
     });
   });

--- a/packages/lib/sdk/tests/pluto/Pluto.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.test.ts
@@ -46,9 +46,9 @@ describe("Pluto", () => {
 
         const resultPrivateKey = resultPeerDID.privateKeys[0];
         expect(resultPrivateKey)
-          .to.have.property("keyCurve")
-          .to.deep.equal({ curve: privateKey.curve });
-        expect(resultPrivateKey).to.have.property("value").to.deep.eq(raw);
+          .to.have.property("curve")
+          .to.equal(privateKey.curve);
+        expect(resultPrivateKey.getEncoded()).to.deep.eq(privateKey.getEncoded());
       });
     });
   });

--- a/packages/shared/domain/src/peer-did/PeerDID.ts
+++ b/packages/shared/domain/src/peer-did/PeerDID.ts
@@ -1,21 +1,8 @@
 import { type KeyCurve, type DID, CastorError } from "../models";
+import { PrivateKey } from "../models/keyManagement/PrivateKey"
 
 export namespace PeerDID {
-    // Q: why is this a custom shape instead of a Domain.PrivateKey?
-    export interface PrivateKey {
-        /**
-         * Instance of a KeyCurve
-         *
-         * @type {KeyCurve}
-         */
-        keyCurve: KeyCurve;
-        /**
-         * Value as Uint8Array, buffer like
-         *
-         * @type {Uint8Array}
-         */
-        value: Uint8Array;
-    }
+
 }
 
 export interface PeerDIDEncoded {
@@ -30,7 +17,7 @@ export interface PeerDIDEncoded {
 export class PeerDID {
     constructor(
         public readonly did: DID,
-        public readonly privateKeys: PeerDID.PrivateKey[] = []
+        public readonly privateKeys: PrivateKey[] = []
     ) {
         const regex = /(([01](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))|(2((\.[AEVID](z)([1-9a-km-zA-HJ-NP-Z]{46,47}))+(\.(S)[0-9a-zA-Z=]*)*)))$/;
         const isValid = did.schema === "did" && did.method === "peer" && regex.test(did.methodId);

--- a/packages/shared/domain/src/peer-did/PeerDID.ts
+++ b/packages/shared/domain/src/peer-did/PeerDID.ts
@@ -1,5 +1,5 @@
-import { type KeyCurve, type DID, CastorError } from "../models";
-import { PrivateKey } from "../models/keyManagement/PrivateKey"
+import { type DID, CastorError } from "../models";
+import { type PrivateKey } from "../models/keyManagement/PrivateKey"
 
 export namespace PeerDID {
 


### PR DESCRIPTION
### Description

replaced the custom `PeerDID.PrivateKey` interface with  existing `Domain.PrivateKey` ,  eliminating the duplicate key type and corresponding manual conversions.This is in reference to  the question:  ` "why is this a custom shape instead of a Domain.PrivateKey?"` 

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
