### PR TITLE
fix(mercury,castor): replace unsafe JWK as any casts with runtime type validation

### DIFF
--- a/packages/lib/sdk/src/castor/methods/prism/index.ts
+++ b/packages/lib/sdk/src/castor/methods/prism/index.ts
@@ -309,8 +309,11 @@ export class PrismDIDMethod
     const { usage, index } = this.getUsageFromId(verificationMethod.id);
 
     if (verificationMethod.publicKeyJwk) {
-      // TODO need to properly parse JWK into key / raw
-      const raw = base64.base64url.baseDecode(verificationMethod.publicKeyJwk.x as any);
+      const xValue = verificationMethod.publicKeyJwk.x;
+      if (typeof xValue !== 'string') {
+        throw new Domain.CastorError.InvalidKeyError('Invalid JWK: x coordinate is missing or not a string');
+      }
+      const raw = base64.base64url.baseDecode(xValue);
 
       if (verificationMethod.publicKeyJwk.crv === Domain.Curve.SECP256K1) {
         return this.createProtos(new Secp256k1PublicKey(raw), usage, index);

--- a/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
+++ b/packages/lib/sdk/src/mercury/DIDCommDIDResolver.ts
@@ -41,8 +41,8 @@ export class DIDCommDIDResolver implements DIDComm.DIDResolver {
               keyAgreements.push(method.id);
               break;
           }
-          const publicKeyBase64 = method.publicKeyJwk?.x as any;
-          const publicKeyKid = (method.publicKeyJwk as any).kid;
+          const publicKeyBase64 = expect(method.publicKeyJwk?.x, CastorError.InvalidKeyError);
+          const publicKeyKid = method.publicKeyJwk?.kid;
           const kty = (curve === Curve.ED25519 || curve === Curve.X25519) ? "OKP" : "EC";
           verificationMethods.push({
             controller: method.controller,

--- a/packages/lib/sdk/tests/mercury/didcomm/DIDResolver.test.ts
+++ b/packages/lib/sdk/tests/mercury/didcomm/DIDResolver.test.ts
@@ -97,4 +97,28 @@ describe("Mercury DIDComm DIDResolver", () => {
       });
     });
   });
+
+  describe("JWK validation", () => {
+    it("should throw InvalidKeyError when JWK x coordinate is missing", async () => {
+      const idDid = Domain.DID.fromString("did:test:id");
+      const vm = new Domain.DIDDocument.VerificationMethod(
+        "vm-ED25519",
+        "1",
+        "Ed25519VerificationKey2018",
+        { crv: Domain.Curve.ED25519, kid: "kid" } as any
+      );
+
+      const castor: Pick<Castor, "resolveDID"> = {
+        resolveDID: async (): Promise<Domain.DIDDocument> =>
+          new Domain.DIDDocument(idDid, [
+            new Domain.DIDDocument.Authentication([], [vm]),
+          ]),
+      };
+
+      const sut = new DIDCommDIDResolver(castor as any);
+      await expect(sut.resolve(idDid.toString())).rejects.toThrow(
+        Domain.CastorError.InvalidKeyError
+      );
+    });
+  });
 });


### PR DESCRIPTION
### Description

Replace unsafe `as any` casts when accessing `x` and `kid` fields on `publicKeyJwk` with proper runtime validation. The previous casts allowed malformed JWK data (missing coordinates, wrong types) to silently pass through the cryptographic verification layer.

**DIDCommDIDResolver.ts**: `publicKeyJwk?.x as any` → `expect(method.publicKeyJwk?.x, CastorError.InvalidKeyError)` which throws `InvalidKeyError` if `x` is missing at runtime. `(method.publicKeyJwk as any).kid` → `method.publicKeyJwk?.kid` (the `as any` was unnecessary since `kid` is already typed on `JWK.Base`).

**prism/index.ts**: `publicKeyJwk.x as any` → explicit `typeof` guard throwing `CastorError.InvalidKeyError` when `x` is missing or not a string.

Existing Mercury DIDResolver test (happy path) continues to pass. New test validates that a verification method with JWK lacking `x` throws `CastorError.InvalidKeyError`.

Fixes #625

### Alternatives Considered (optional)

- Creating a shared `parseJWKCoordinate` utility — the existing `expect()` helper and explicit type guards are simpler and sufficient for these two locations
- Using a non-null assertion (`!`) — this would only silence TypeScript without runtime protection

### Checklist

- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)