### PR TITLE
fix(pollux): add regex validation to prevent ReDoS in presentation verification

### DIFF
--- a/packages/lib/sdk/src/plugins/internal/dif/PresentationVerify.ts
+++ b/packages/lib/sdk/src/plugins/internal/dif/PresentationVerify.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as Domain from "@hyperledger/identus-domain";
-import { asArray, asJsonObj } from "../../../utils";
+import { asArray, asJsonObj, isSafeRegex } from "../../../utils";
 import { IsCredentialRevoked } from "./IsCredentialRevoked";
 import { Payload } from "@hyperledger/identus-domain";
 import { JWTCredential } from "../../../pollux/models/JWTVerifiableCredential";
@@ -239,6 +239,12 @@ export class PresentationVerify extends Plugins.Task<Args> {
         const filter = field.filter;
 
         if (filter.pattern) {
+          if (!isSafeRegex(filter.pattern)) {
+            throw new Domain.PolluxError.InvalidVerifyCredentialError(
+              vc,
+              "Invalid Claim: The provided pattern is not a safe regular expression"
+            );
+          }
           const pattern = new RegExp(filter.pattern);
           if (!pattern.test(value) && value !== filter.pattern) {
             throw new Domain.PolluxError.InvalidVerifyCredentialError(

--- a/packages/lib/sdk/src/utils/index.ts
+++ b/packages/lib/sdk/src/utils/index.ts
@@ -6,4 +6,5 @@ export { isNil, notNil, isObject, isString, isArray, notEmptyString, isEmpty, as
 export { ConsoleLogger } from "./logger";
 export type { Logger, LogLevel } from "./logger";
 export * from "./tasks";
+export { isSafeRegex } from "./safeRegex";
 export type { Arrayable, Ctor, Nil, JsonObj, Normalize } from "./types";

--- a/packages/lib/sdk/src/utils/safeRegex.ts
+++ b/packages/lib/sdk/src/utils/safeRegex.ts
@@ -1,0 +1,92 @@
+const MAX_PATTERN_LENGTH = 256;
+
+function hasNestedQuantifier(pattern: string): boolean {
+  const stack: string[] = [];
+  let i = 0;
+
+  while (i < pattern.length) {
+    if (pattern[i] === "\\") {
+      i += 2;
+      continue;
+    }
+    if (pattern[i] === "(") {
+      stack.push("(");
+      i++;
+      continue;
+    }
+    if (pattern[i] === ")") {
+      if (stack.length > 0) {
+        stack.pop();
+        const next = i + 1;
+        if (next < pattern.length && (pattern[next] === "+" || pattern[next] === "*" || pattern[next] === "?")) {
+          return true;
+        }
+      }
+      i++;
+      continue;
+    }
+    if (pattern[i] === "[" || pattern[i] === "]" || pattern[i] === "{") {
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return false;
+}
+
+function hasAlternationInGroup(pattern: string): boolean {
+  let depth = 0;
+  let groupStart = -1;
+
+  for (let i = 0; i < pattern.length; i++) {
+    if (pattern[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (pattern[i] === "(") {
+      if (depth === 0) groupStart = i;
+      depth++;
+      continue;
+    }
+    if (pattern[i] === ")") {
+      if (depth > 0) {
+        const next = i + 1;
+        if (depth === 1 && next < pattern.length && (pattern[next] === "+" || pattern[next] === "*" || pattern[next] === "?")) {
+          const inner = pattern.slice(groupStart + 1, i);
+          if (inner.includes("|")) {
+            return true;
+          }
+        }
+        depth--;
+      }
+      continue;
+    }
+  }
+  return false;
+}
+
+export function isSafeRegex(pattern: string): boolean {
+  if (typeof pattern !== "string" || pattern.length === 0) {
+    return false;
+  }
+
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return false;
+  }
+
+  try {
+    new RegExp(pattern);
+  } catch {
+    return false;
+  }
+
+  if (hasNestedQuantifier(pattern)) {
+    return false;
+  }
+
+  if (hasAlternationInGroup(pattern)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
### Description

Add regex pattern validation to `PresentationVerify.ts` to prevent ReDoS (Regular Expression Denial of Service) attacks. The `filter.pattern` field from an externally-supplied presentation definition was passed directly to `new RegExp()` without safety checks, allowing an attacker to craft a malicious regex that causes catastrophic backtracking (e.g. `(a|aa)+b`, `(a+)+b`), blocking the JavaScript event loop indefinitely.

Fixes #646

**Changes:**
- New `packages/lib/sdk/src/utils/safeRegex.ts` utility with `isSafeRegex()` function that validates regex patterns for safety
- Updated `packages/lib/sdk/src/utils/index.ts` to export `isSafeRegex`
- Updated `validateField` in `PresentationVerify.ts` to validate the pattern before constructing the RegExp

**Validation performed by `isSafeRegex()`:**
1. Checks the pattern is a non-empty string
2. Enforces a maximum pattern length of 256 characters
3. Verifies the pattern compiles as a valid RegExp
4. Rejects patterns with nested quantifiers (e.g. `(a+)+`, `(a*)*`, `(a?)?`, `(a|aa)+b`) which are known ReDoS vectors

### Alternatives Considered

- Using the `re2` library for safe regex: rejected to avoid adding a new dependency
- Rejecting all regex patterns and using string matching only: too restrictive for valid use cases
- Using a worker thread with timeout: too complex and adds latency

The selected approach provides defense-in-depth: length limits prevent large-pattern attacks, compilation validation prevents syntax errors, and nested quantifier detection blocks the most common ReDoS vectors.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
