### PR TITLE
fix(pluto): improve onlyOne() error message with diagnostic context

### DIFF
--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -677,7 +677,7 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
     });
 
     // ?? this seems presumptuous? couldnt hostDID be re-used?
-    const link = this.onlyOne(links);
+    const link = this.onlyOne(links, `getPairByDID(${did.toString()})`);
     const didPair = this.mapDIDPairToDomain(link);
 
     return didPair;
@@ -694,7 +694,7 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
       {
         selector: { alias, role: Models.DIDLink.role.pair }
       });
-    const link = this.onlyOne(links);
+    const link = this.onlyOne(links, `getPairByName(${alias})`);
     const didPair = this.mapDIDPairToDomain(link);
 
     return didPair;
@@ -785,9 +785,19 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
     });
   }
 
-  private onlyOne<T>(arr: T[]): T {
-    const item = arr.at(0);
-    if (!item || arr.length !== 1) throw new Error("something wrong");
+  private onlyOne<T>(arr: T[], context?: string): T {
+    if (arr.length !== 1) {
+      throw new Error(
+        `Expected one result but got ${arr.length}${context ? `: ${context}` : ""}`
+      );
+    }
+
+    const item = arr[0];
+    if (!item) {
+      throw new Error(
+        `Unexpected empty result${context ? `: ${context}` : ""}`
+      );
+    }
 
     return item;
   }

--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -740,7 +740,9 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
         const routingLink = links.find(x => x.hostId === hostId && x.role === Models.DIDLink.role.routing.valueOf());
 
         if (!mediatorLink || !routingLink) {
-          throw new Error();
+          throw new Error(
+            `Missing mediator or routing DID link for hostId: ${hostId}`
+          );
         }
 
         const hostDID = await this.Repositories.DIDs.byUUID(hostId);
@@ -748,7 +750,9 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
         const routingDID = await this.Repositories.DIDs.byUUID(routingLink.targetId);
 
         if (!hostDID || !mediatorDID || !routingDID) {
-          throw new Error();
+          throw new Error(
+            `Empty DID for hostId: ${hostId} (host: ${!!hostDID}, mediator: ${!!mediatorDID}, routing: ${!!routingDID})`
+          );
         }
 
         const domain: Domain.Mediator = { hostDID, mediatorDID, routingDID };

--- a/packages/lib/sdk/src/pluto/Pluto.ts
+++ b/packages/lib/sdk/src/pluto/Pluto.ts
@@ -739,6 +739,8 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
         const mediatorLink = links.find(x => x.hostId === hostId && x.role === Models.DIDLink.role.mediator.valueOf());
         const routingLink = links.find(x => x.hostId === hostId && x.role === Models.DIDLink.role.routing.valueOf());
 
+        // One of the two expected DID links (mediator or routing) is
+        // missing for this host — data integrity issue.
         if (!mediatorLink || !routingLink) {
           throw new Error(
             `Missing mediator or routing DID link for hostId: ${hostId}`
@@ -749,6 +751,8 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
         const mediatorDID = await this.Repositories.DIDs.byUUID(mediatorLink.targetId);
         const routingDID = await this.Repositories.DIDs.byUUID(routingLink.targetId);
 
+        // A DID that should exist (host, mediator, or routing) resolved
+        // to null — data integrity or ordering issue.
         if (!hostDID || !mediatorDID || !routingDID) {
           throw new Error(
             `Empty DID for hostId: ${hostId} (host: ${!!hostDID}, mediator: ${!!mediatorDID}, routing: ${!!routingDID})`
@@ -789,6 +793,18 @@ export class Pluto extends Domain.Startable.Controller implements Domain.Pluto {
     });
   }
 
+  /**
+   * Assert that an array has exactly one element and return it.
+   *
+   * Accepts an optional `context` string so callers can identify
+   * themselves in the error message (e.g. the DID or alias being
+   * looked up) — makes debugging much faster than a bare
+   * `"something wrong"`.
+   *
+   * Two distinct failure modes are reported:
+   * - `arr.length !== 1`  — reports the actual count
+   * - `arr[0]` is falsy    — reports an unexpected null/empty slot
+   */
   private onlyOne<T>(arr: T[], context?: string): T {
     if (arr.length !== 1) {
       throw new Error(

--- a/packages/lib/sdk/tests/pluto/Pluto.test.ts
+++ b/packages/lib/sdk/tests/pluto/Pluto.test.ts
@@ -384,6 +384,90 @@ describe("Pluto", () => {
     expect(result?.body).deep.equal(message.body);
   });
 
+  describe("onlyOne error context", () => {
+    it("should throw with context when getPairByName finds no results", async () => {
+      await expect(
+        instance.getPairByName("nonexistent")
+      ).rejects.toThrow(/Expected one result but got 0.*getPairByName/);
+    });
+
+    it("should throw with context when getPairByName finds multiple results", async () => {
+      const host1 = SDK.Domain.DID.fromString("did:prism:111");
+      const receiver1 = SDK.Domain.DID.fromString("did:prism:222");
+      const host2 = SDK.Domain.DID.fromString("did:prism:333");
+      const receiver2 = SDK.Domain.DID.fromString("did:prism:444");
+      const name = "duplicate";
+
+      const pk = new SDK.Ed25519PrivateKey(
+        Buffer.from("01011010011101010100011000100010")
+      );
+      for (const did of [host1, receiver1, host2, receiver2]) {
+        await instance.storePrismDID(did, pk);
+      }
+
+      await instance.storeDIDPair(host1, receiver1, name);
+      await instance.storeDIDPair(host2, receiver2, name);
+
+      await expect(
+        instance.getPairByName(name)
+      ).rejects.toThrow(/Expected one result but got 2.*getPairByName/);
+    });
+  });
+
+  describe("getAllMediators error handling", () => {
+    it("should throw when mediator link exists without routing link", async () => {
+      const hostDID = SDK.Domain.DID.fromString("did:prism:901");
+      const mediatorDID = SDK.Domain.DID.fromString("did:prism:902");
+      const pk = new SDK.Ed25519PrivateKey(
+        Buffer.from("01011010011101010100011000100010")
+      );
+      await instance.storePrismDID(hostDID, pk);
+      await instance.storePrismDID(mediatorDID, pk);
+
+      // Insert a mediator link without the corresponding routing link
+      await (instance.store as any).insert("did-link", {
+        uuid: randomUUID(),
+        role: 2,
+        hostId: hostDID.uuid,
+        targetId: mediatorDID.uuid,
+      });
+
+      await expect(
+        instance.getAllMediators()
+      ).rejects.toThrow(/Missing mediator or routing DID link for hostId/);
+    });
+
+    it("should throw when DIDs are missing for stored links", async () => {
+      const hostDID = SDK.Domain.DID.fromString("did:prism:903");
+      const mediatorDID = SDK.Domain.DID.fromString("did:prism:904");
+      const routingDID = SDK.Domain.DID.fromString("did:prism:905");
+      const pk = new SDK.Ed25519PrivateKey(
+        Buffer.from("01011010011101010100011000100010")
+      );
+      await instance.storePrismDID(hostDID, pk);
+      await instance.storePrismDID(mediatorDID, pk);
+      // Intentionally NOT storing routingDID
+
+      // Insert both links but routing DID won't resolve
+      await (instance.store as any).insert("did-link", {
+        uuid: randomUUID(),
+        role: 2,
+        hostId: hostDID.uuid,
+        targetId: mediatorDID.uuid,
+      });
+      await (instance.store as any).insert("did-link", {
+        uuid: randomUUID(),
+        role: 3,
+        hostId: hostDID.uuid,
+        targetId: routingDID.uuid,
+      });
+
+      await expect(
+        instance.getAllMediators()
+      ).rejects.toThrow(/Empty DID for hostId/);
+    });
+  });
+
   //
   it("should get all mediators", async function () {
     const mediator = SDK.Domain.DID.fromString("did:prism:123");


### PR DESCRIPTION
### Description

The `onlyOne()` method in `Pluto.ts` throws a generic `new Error("something wrong")` with no diagnostic context, making it impossible to identify what query failed or why.

Changes:
- `onlyOne()` now accepts an optional context string to identify the caller
- Distinguishes between empty results (`arr.length === 0`) and multiple results
- Reports the actual count when >1 result is found
- Passes context from `getPairByDID()` and `getPairByName()` callers
- Adds diagnostic context to `getAllMediators()` error messages (was bare `throw new Error()` with no message)
- Adds comprehensive tests for error paths in `onlyOne()` and `getAllMediators()`

Fixes #648

### Alternatives Considered

- Using a typed `PlutoError` subclass — overkill for a private helper; callers already handle errors appropriately
- Making `onlyOne()` public — unnecessary; only used internally

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that dont comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)