### PR TITLE
ci(lint): ignore all generated CHANGELOGs in markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -5,4 +5,4 @@ ignores:
   - "coverage/**"
   - "externals/**"
   - "docs/sdk/**"
-  - "CHANGELOG.md"
+  - "**/CHANGELOG.md"


### PR DESCRIPTION
## Problem

The **File Hygiene** workflow (`lint / Markdown` job) has been failing on every PR since the last `nx release`, e.g. on Dependabot PR #661:

- Run: https://github.com/hyperledger-identus/sdk-ts/actions/runs/27996165777/job/82858697467

All 7 failures are `MD047/single-trailing-newline` on per-package CHANGELOGs:

```
packages/lib/protos/CHANGELOG.md
packages/lib/sdk/CHANGELOG.md
packages/shared/domain/CHANGELOG.md
packages/wasm/anoncreds/CHANGELOG.md
packages/wasm/config/CHANGELOG.md
packages/wasm/didcomm/CHANGELOG.md
packages/wasm/jwe/CHANGELOG.md
```

## Root cause

`file-hygiene.yml` calls the shared reusable workflow `hyperledger-identus/.github/.github/workflows/lint-files.yml`, which runs `markdownlint-cli2-action` over `**/*.md`.

The repo's `.markdownlint-cli2.yaml` ignored only the **root** `CHANGELOG.md`:

```yaml
ignores:
  - "CHANGELOG.md"
```

The per-package `packages/**/CHANGELOG.md` files are **auto-generated** by `nx release` (commit `chore(release): [skip ci]`) and are written without a trailing newline. Because they were not ignored, they were linted and failed MD047. After each release rewrites them, every subsequent PR fails the lint job.

## Fix

Change the ignore from `"CHANGELOG.md"` to `"**/CHANGELOG.md"` so all generated changelogs (root + per-package) are exempt — consistent with how the root changelog was already handled. Generated content should not be hand-linted.

```diff
 ignores:
   - ".claude/**"
   - "node_modules/**"
   - "**/node_modules/**"
   - "coverage/**"
   - "externals/**"
   - "docs/sdk/**"
-  - "CHANGELOG.md"
+  - "**/CHANGELOG.md"
```

## Verification

- Locally: `markdownlint-cli2 '**/*.md'` → `Summary: 0 error(s)` (44 files linted, down from 51; the 7 CHANGELOGs are now excluded).
- CI: pending on this PR.

This is a permanent fix: future `nx release` runs can regenerate the per-package CHANGELOGs without a trailing newline and the lint job will stay green.