### PR TITLE
feat: implement deactivate prism:did operations on sdk-ts

### DIFF
--- a/packages/lib/sdk/src/castor/methods/prism/index.ts
+++ b/packages/lib/sdk/src/castor/methods/prism/index.ts
@@ -32,6 +32,8 @@ export type DeactivatePayload = {
   key: Domain.PrivateKey;
   /** The DID to deactivate. */
   did: Domain.DID;
+  /** The previous operation hash (last operation hash, create, update, deactivate) */
+  previousOperationHash: Uint8Array;
 };
 
 /**
@@ -178,7 +180,7 @@ export type Metadata = Uint8Array
  * ```
  */
 export class PrismDIDMethod
-  implements DIDMethod<Metadata, CreatePayload, PublishPayload, UpdatePayload> {
+  implements DIDMethod<Metadata, CreatePayload, PublishPayload, UpdatePayload, DeactivatePayload> {
   method = "prism" as const;
   resolver: PrismDIDResolver;
 
@@ -187,6 +189,24 @@ export class PrismDIDMethod
    */
   constructor(prismResolverEndpoint: string) {
     this.resolver = new PrismDIDResolver(prismResolverEndpoint);
+  }
+
+  /**
+   * The previous operation hash is the hash of the last operation, create, update, deactivate
+   * We can use the neoprism API to get the last operation hash for a specific did and TX
+   */
+  async deactivate(opts: DeactivatePayload): Promise<DIDMethodOperation<Metadata>> {
+    const { key, previousOperationHash } = opts;
+    const deactivateDID = new Protos.io.iohk.atala.prism.protos.DeactivateDIDOperation({
+      previous_operation_hash: previousOperationHash,
+      id: '2',
+    });
+
+    const operation = new Protos.io.iohk.atala.prism.protos.AtalaOperation({
+      deactivate_did: deactivateDID,
+    });
+
+    return this.signOperation(operation, key);
   }
 
   /**

--- a/packages/lib/sdk/tests/castor/AtalaOperation.test.ts
+++ b/packages/lib/sdk/tests/castor/AtalaOperation.test.ts
@@ -99,6 +99,86 @@ describe("AtalaOperation", () => {
     expect(verify).toBe(true);
   });
 
+  it("Should create a signed prism did deactivate AtalaObject", async () => {
+    const { publicKey, privateKey } = Fixtures.Keys.secp256K1;
+
+    const did = await castor.createDID('prism', {
+      keys: {
+        MASTER_KEY: privateKey,
+      },
+    });
+    const previousOperationHash = new Uint8Array(
+      (new SHA256()).update(Buffer.from("previous")).digest()
+    );
+    const atalaObjectBuffer = await castor.deactivateDID(
+      'prism',
+      {
+        key: privateKey,
+        did: did,
+        previousOperationHash,
+      }
+    );
+    const atalaObject = Protos.io.iohk.atala.prism.protos.AtalaObject.deserializeBinary(atalaObjectBuffer);
+    expect(atalaObject).toHaveProperty("block_content");
+    expect(atalaObject.block_content).toHaveProperty("operations");
+    expect(atalaObject.block_content.operations).toHaveLength(1);
+    expect(atalaObject.block_content.operations[0]).toHaveProperty("operation");
+    expect(atalaObject.block_content.operations[0].operation).toHaveProperty("deactivate_did");
+    expect(atalaObject.block_content.operations[0].operation.deactivate_did).toHaveProperty("previous_operation_hash");
+    expect(Buffer.from(atalaObject.block_content.operations[0].operation.deactivate_did.previous_operation_hash))
+      .toEqual(Buffer.from(previousOperationHash));
+    const signedOperation = atalaObject.block_content.operations[0];
+    expect(signedOperation.signed_with).to.equal("master-0");
+    const signature = Buffer.from(signedOperation.signature);
+    const operation = signedOperation.operation;
+    const serializedOperation = operation.serializeBinary();
+    const verify = publicKey.verify(Buffer.from(serializedOperation), signature);
+    expect(verify).toBe(true);
+  });
+
+  it("Should be able to verify a created deactivate AtalaObject", async () => {
+    const randomSeed = apollo.createRandomSeed().seed.value;
+    const masterSK = await apollo.createPrivateKey({
+      type: Domain.KeyTypes.EC,
+      curve: Domain.Curve.SECP256K1,
+      seed: randomSeed,
+    });
+    const did = await castor.createDID('prism', {
+      keys: {
+        MASTER_KEY: masterSK,
+      },
+    });
+    const previousOperationHash = new Uint8Array(
+      (new SHA256()).update(Buffer.from("previous")).digest()
+    );
+    const atalaObjectBuffer = await castor.deactivateDID(
+      'prism',
+      {
+        key: masterSK,
+        did: did,
+        previousOperationHash,
+      }
+    );
+    const atalaObject = Protos.io.iohk.atala.prism.protos.AtalaObject.deserializeBinary(atalaObjectBuffer);
+    expect(atalaObject).toHaveProperty("block_content");
+    expect(atalaObject.block_content).toBeInstanceOf(Protos.io.iohk.atala.prism.protos.AtalaBlock);
+    const atalaBlock = atalaObject.block_content;
+    expect(atalaBlock).toHaveProperty("operations");
+    expect(atalaBlock.operations).toBeInstanceOf(Array);
+    const signedOperations = atalaBlock.operations;
+    expect(signedOperations.length).toBe(1);
+    const signedOperation = signedOperations[0];
+    expect(signedOperation).toHaveProperty('operation');
+    expect(signedOperation).toHaveProperty('signature');
+    expect(signedOperation.operation).toHaveProperty('deactivate_did');
+    const signature = Buffer.from(signedOperation.signature);
+    const operation = signedOperation.operation;
+    const serializedOperation = operation.serializeBinary();
+    const verifiableKey = masterSK.publicKey() as PublicKey & VerifiableKey;
+    const verify = verifiableKey.verify(Buffer.from(serializedOperation), signature);
+    expect(verify).toBe(true);
+  });
+
   it("Should be able to recover a valid operations and verify its signatures", async () => {
     const atalaObjects = [
       [


### PR DESCRIPTION
### Description

This pull request implements the deactivate prism:did operation, whenever a DID is published, updated or deactivated upon submitting the transaction we will get  the TxID, we will need to store it somewhere and use [this endpoint](https://neoprism.patlo.dev/openapi#tag/indexer-api/GET/api/transactions/{tx_id}) to get the latest operation hash into the deactivate operation.

Code breakdown:

```typescript
castor.deactivateDID("prism", {previousOperationHash: Uint8Array}) => AtalaObject 
```

This AtalaObject needs to be submitted to the neoprism node or to one of the existing web3 wallets in Cardano.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-ts/blob/master/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
